### PR TITLE
Renamed and better documented the compile time constants

### DIFF
--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.c
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.c
@@ -397,7 +397,7 @@ static MQTTContext_t mqttContexts[ MQTT_AGENT_MAX_OUTSTANDING_ACKS ] = { 0 };
 /**
  * @brief The network buffer must remain valid for the lifetime of the MQTT context.
  */
-static uint8_t networkBuffers[ MQTT_AGENT_MAX_OUTSTANDING_ACKS ][ mqttexampleNETWORK_BUFFER_SIZE ];/*_RB_ Need to move and rename constant. Also this requires both buffers to be the same size. */
+static uint8_t networkBuffers[ MQTT_AGENT_MAX_OUTSTANDING_ACKS ][ MQTT_AGENT_NETWORK_BUFFER_SIZE ];
 
 /**
  * @brief The pool of command structures used to hold information on commands (such
@@ -648,7 +648,7 @@ static MQTTStatus_t createCommand( CommandType_t commandType,
     /* Determine if required parameters are present in context. */
     switch( commandType )
     {
-        case SUBSCRIBE:
+        case SUBSCRIBE: /*_RB_ Should not be accepted if MQTT_AGENT_MAX_OUTSTANDING_ACKS has been reached. */
             pSubscribeInfo = ( MQTTSubscribeInfo_t * ) pMqttInfoParam;
             isValid = ( pMqttContext != NULL ) && 
                       ( pMqttInfoParam != NULL ) && 
@@ -660,7 +660,7 @@ static MQTTStatus_t createCommand( CommandType_t commandType,
             isValid = ( pMqttContext != NULL ) && ( pMqttInfoParam != NULL );
             break;
 
-        case PUBLISH:
+        case PUBLISH:/*_RB_ Should not be accepted if MQTT_AGENT_MAX_OUTSTANDING_ACKS has been reached or if the payload length is greater than MQTT_AGENT_NETWORK_BUFFER_SIZE. */
             isValid = ( pMqttContext != NULL ) && ( pMqttInfoParam != NULL );
             break;
 
@@ -1234,7 +1234,7 @@ MQTTStatus_t MQTTAgent_Init( MQTTContextHandle_t mqttContextHandle,
     {
         /* Fill the values for network buffer. */
         networkBuffer.pBuffer = &( networkBuffers[ mqttContextHandle ][ 0 ] );
-        networkBuffer.size = mqttexampleNETWORK_BUFFER_SIZE;
+        networkBuffer.size = MQTT_AGENT_NETWORK_BUFFER_SIZE;
 
         returnStatus = MQTT_Init( &( mqttContexts[ mqttContextHandle ] ),
                                   pTransportInterface,

--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
@@ -31,54 +31,63 @@
 #ifndef MQTT_AGENT_H
 #define MQTT_AGENT_H
 
-/* Demo Specific configs. */
-#include "demo_config.h" //_RB_ Remove this.
-
 /* MQTT library includes. */
 #include "core_mqtt.h"
 #include "core_mqtt_state.h"
 
 
 /**
- * @brief The maximum number of MQTT connections that can be tracked.
- */
-#ifndef MQTT_AGENT_MAX_CONNECTIONS
-    #define MQTT_AGENT_MAX_SIMULTANEOUS_CONNECTIONS           1
-#endif
-
-/**
  * @brief The maximum number of pending acknowledgments to track for a single
  * connection.
+ * @note The MQTT agent tracks MQTT commands (such as PUBLISH and SUBSCRIBE) th
+ * at are still waiting to be acknowledged.  MQTT_AGENT_MAX_OUTSTANDING_ACKS set
+ * the maximum number of acknowledgments that can be outstanding at any one time.
+ * The higher this number is the greater the agent's RAM consumption will be.
  */
 #ifndef MQTT_AGENT_MAX_OUTSTANDING_ACKS
-    #define MQTT_AGENT_MAX_OUTSTANDING_ACKS                  20
+    #define MQTT_AGENT_MAX_OUTSTANDING_ACKS               ( 20 )
 #endif
 
 /**
  * @brief The maximum number of subscriptions to track for a single connection.
+ * @note The MQTT agent keeps a record of all existing MQTT subscriptions.
+ * MQTT_AGENT_MAX_SIMULTANEOUS_SUBSCRIPTIONS sets the maximum number of
+ * subscriptions records that can be maintained at one time.  The higher this
+ * number is the greater the agents RAM consumption will be.
  */
 #ifndef MQTT_AGENT_MAX_SIMULTANEOUS_SUBSCRIPTIONS
-    #define MQTT_AGENT_MAX_SIMULTANEOUS_SUBSCRIPTIONS            10
+    #define MQTT_AGENT_MAX_SIMULTANEOUS_SUBSCRIPTIONS     ( 10 )
 #endif
 
 /**
  * @brief Size of statically allocated buffers for holding subscription filters.
+ * @note Subscription filters are strings such as "/my/topicname/#".  These
+ * strings are limited to a maximum of MQTT_AGENT_MAX_SUBSCRIPTION_FILTER_LENGTH
+ * characters. The higher this number is the greater the agent's RAM consumption
+ * will be.
  */
 #ifndef MQTT_AGENT_MAX_SUBSCRIPTION_FILTER_LENGTH
-    #define MQTT_AGENT_MAX_SUBSCRIPTION_FILTER_LENGTH    100
+    #define MQTT_AGENT_MAX_SUBSCRIPTION_FILTER_LENGTH     ( 100 )
 #endif
 
 /**
- * @brief Time in MS that the MQTT agent task will wait in the Blocked state (so not
- * using any CPU time) for a command to arrive in its command queue before exiting
- * the blocked state so it can call MQTT_ProcessLoop().  It is important 
- * MQTT_ProcessLoop() is called often if there is known MQTT traffic, but calling it
- * too often can take processing time away from lower priority tasks and waste CPU
- * time and power.
+ * @brief Time in MS that the MQTT agent task will wait in the Blocked state (so
+ * not using any CPU time) for a command to arrive in its command queue before
+ * exiting the blocked state so it can call MQTT_ProcessLoop().
+ * @note It is important MQTT_ProcessLoop() is called often if there is known
+ * MQTT traffic, but calling it too often can take processing time away from
+ * lower priority tasks and waste CPU time and power.
  */
 #ifndef MQTT_AGENT_MAX_EVENT_QUEUE_WAIT_TIME
-    #define MQTT_AGENT_MAX_EVENT_QUEUE_WAIT_TIME             pdMS_TO_TICKS( 1000 )
+    #define MQTT_AGENT_MAX_EVENT_QUEUE_WAIT_TIME          pdMS_TO_TICKS( 1000 )
 #endif
+
+/**
+ * @brief Dimensions the buffer used to  serialise and deserialise MQTT packets.
+ * @note Specified in bytes.  Must be large enough to hold the maximum
+ * anticipated MQTT payload.
+ */
+#define MQTT_AGENT_NETWORK_BUFFER_SIZE                    ( 5000 )
 
 /*-----------------------------------------------------------*/
 

--- a/source/LargeMessageSubscribePublish.c
+++ b/source/LargeMessageSubscribePublish.c
@@ -66,7 +66,7 @@
 #define mqttexampleMAX_COMMAND_SEND_BLOCK_TIME_MS   200
 
 #define mqttexamplePROTOCOL_OVERHEAD 50
-#define mqttexampleMAX_PAYLOAD_LENGTH ( mqttexampleNETWORK_BUFFER_SIZE - mqttexamplePROTOCOL_OVERHEAD )
+#define mqttexampleMAX_PAYLOAD_LENGTH ( MQTT_AGENT_NETWORK_BUFFER_SIZE - mqttexamplePROTOCOL_OVERHEAD )
 
 /*-----------------------------------------------------------*/
 
@@ -153,23 +153,23 @@ void vLargeMessageSubscribePublishTask( void * pvParameters )
     BaseType_t x;
     char c = '0';
     const char* topicBuf = "/max/payload/message";
-    volatile CommandContext_t xApplicationDefinedContext = { 0 };
+    CommandContext_t xApplicationDefinedContext = { 0 };
     MQTTStatus_t xCommandAdded;
     MQTTSubscribeInfo_t xSubscribeInfo;
 
     ( void ) pvParameters;
 
     /* Create a large buffer of data. */
-    for( x = 0; x < mqttexampleNETWORK_BUFFER_SIZE; x++ )
+    for( x = 0; x < MQTT_AGENT_NETWORK_BUFFER_SIZE; x++ )
     {
-        if( x < mqttexampleNETWORK_BUFFER_SIZE / 2 )
-		{
+        if( x < MQTT_AGENT_NETWORK_BUFFER_SIZE / 2 )
+        {
             maxPayloadMessage[ x ] = 'a';
-		}
+        }
         else
-		{
+        {
             maxPayloadMessage[ x ] = 'b';
-		}
+        }
         c++;
 
         /* Keep the characters human readable. */
@@ -259,3 +259,4 @@ void vLargeMessageSubscribePublishTask( void * pvParameters )
         vTaskDelay( pdMS_TO_TICKS( mqttDELAY_BETWEEN_PUBLISH_OPERATIONS_MS ) );
     }
 }
+


### PR DESCRIPTION
This also removes the agent's dependency on demo_config.h, so you may need to add constants to core_mqtt_config.h to continue compiling.