### PR TITLE
Separate command pool and queue

### DIFF
--- a/build/VisualStudio/WIN32.vcxproj
+++ b/build/VisualStudio/WIN32.vcxproj
@@ -28,10 +28,12 @@
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-kernel\stream_buffer.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-kernel\tasks.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-kernel\timers.c" />
+    <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\agent_command_pool.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\coreMQTT\source\core_mqtt.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\coreMQTT\source\core_mqtt_serializer.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\coreMQTT\source\core_mqtt_state.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\freertos_mqtt_agent.c" />
+    <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\mqtt_agent_queue.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-tcp\FreeRTOS_ARP.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-tcp\FreeRTOS_DHCP.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-tcp\FreeRTOS_DNS.c" />
@@ -79,12 +81,14 @@
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-kernel\include\task.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-kernel\include\timers.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-kernel\portable\MSVC-MingW\portmacro.h" />
+    <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\agent_command_pool.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\coreMQTT\source\include\core_mqtt.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\coreMQTT\source\include\core_mqtt_config_defaults.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\coreMQTT\source\include\core_mqtt_serializer.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\coreMQTT\source\include\core_mqtt_state.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\coreMQTT\source\interface\transport_interface.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\freertos_mqtt_agent.h" />
+    <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\mqtt_agent_queue.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-tcp\include\FreeRTOSIPConfigDefaults.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-tcp\include\FreeRTOS_ARP.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-tcp\include\FreeRTOS_DHCP.h" />

--- a/build/VisualStudio/WIN32.vcxproj.filters
+++ b/build/VisualStudio/WIN32.vcxproj.filters
@@ -291,6 +291,12 @@
     <ClCompile Include="..\..\source\simple_sub_pub_demo.c">
       <Filter>Source</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\agent_command_pool.c">
+      <Filter>Lib\FreeRTOS\FreeRTOS-Plus-MQTT</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\mqtt_agent_queue.c">
+      <Filter>Lib\FreeRTOS\FreeRTOS-Plus-MQTT</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-kernel\portable\MSVC-MingW\portmacro.h">
@@ -457,6 +463,12 @@
     </ClInclude>
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-kernel\include\event_groups.h">
       <Filter>Lib\FreeRTOS\FreeRTOS-Kernel\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\agent_command_pool.h">
+      <Filter>Lib\FreeRTOS\FreeRTOS-Plus-MQTT</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-mqtt\mqtt_agent_queue.h">
+      <Filter>Lib\FreeRTOS\FreeRTOS-Plus-MQTT</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/lib/FreeRTOS/freertos-plus-mqtt/agent_command_pool.c
+++ b/lib/FreeRTOS/freertos-plus-mqtt/agent_command_pool.c
@@ -1,0 +1,136 @@
+/*
+ * FreeRTOS V202011.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/**
+ * @file agent_command_pool.c
+ * @brief Implements functions to obtain and release commands.
+ */
+
+/* Standard includes. */
+#include <string.h>
+#include <stdio.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "semphr.h"
+
+/* Header include. */
+#include "agent_command_pool.h"
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The pool of command structures used to hold information on commands (such
+ * as PUBLISH or SUBSCRIBE) between the command being created by an API call and
+ * by either an error or the execution of the commands callback.
+ */
+static Command_t commandStructurePool[ MQTT_COMMAND_CONTEXTS_POOL_SIZE ];
+
+/**
+ * @brief A counting semaphore used to guard the pool of Command_t structures.  To
+ * obtain a structure first decrement the semaphore count.  To return a structure
+ * increment the semaphore count after the structure is back in the pool.
+ */
+static SemaphoreHandle_t freeCommandStructMutex = NULL;
+
+/*-----------------------------------------------------------*/
+
+Command_t * Agent_GetCommand( uint32_t blockTimeMs )
+{
+    Command_t * structToUse = NULL;
+    size_t i;
+    static bool initialized = false;
+
+    if( !initialized )
+    {
+        memset( ( void * ) commandStructurePool, 0x00, sizeof( commandStructurePool ) );
+        freeCommandStructMutex = xSemaphoreCreateCounting( MQTT_COMMAND_CONTEXTS_POOL_SIZE, MQTT_COMMAND_CONTEXTS_POOL_SIZE );
+        configASSERT( freeCommandStructMutex ); /*_RB_ Create all objects here statically. */
+
+        initialized = true;
+    }
+
+    /* Check counting semaphore has been created. */
+    if( freeCommandStructMutex != NULL )
+    {
+        /* If the semaphore count is not zero then a command context is available. */
+        if( xSemaphoreTake( freeCommandStructMutex, pdMS_TO_TICKS( blockTimeMs ) ) == pdPASS )
+        {
+            for( i = 0; i < MQTT_COMMAND_CONTEXTS_POOL_SIZE; i++ )
+            {
+                taskENTER_CRITICAL();
+                {
+                    /* If the commandType is NONE then the structure is not in use. */
+                    if( commandStructurePool[ i ].commandType == NONE )
+                    {
+                        LogDebug( ( "Removed Command Context %d from pool", ( int ) i ) );
+                        structToUse = &( commandStructurePool[ i ] );
+
+                        /* To show the struct is no longer available to be returned
+                         * by calls to Agent_ReleaseCommand(). */
+                        structToUse->commandType = !NONE;
+                        taskEXIT_CRITICAL();
+                        break;
+                    }
+                }
+                taskEXIT_CRITICAL();
+            }
+        }
+    }
+
+    return structToUse;
+}
+
+/*-----------------------------------------------------------*/
+
+bool Agent_ReleaseCommand( Command_t * pCommandToRelease )
+{
+    size_t i;
+    bool structReturned = false;
+
+    /* See if the structure being returned is actually from the pool. */
+    for( i = 0; i < MQTT_COMMAND_CONTEXTS_POOL_SIZE; i++ )
+    {
+        if( pCommandToRelease == &( commandStructurePool[ i ] ) )
+        {
+            /* Yes its from the pool.  Clearing it to zero not only removes the old
+             * data it also sets the structure's commandType parameter to NONE to
+             * mark the structure as free again. */
+            memset( ( void * ) pCommandToRelease, 0x00, sizeof( Command_t ) );
+
+            /* Give back the counting semaphore after returning the structure so the
+             * semaphore count equals the number of available structures. */
+            xSemaphoreGive( freeCommandStructMutex );
+            structReturned = true;
+
+            LogDebug( ( "Returned Command Context %d to pool", ( int ) i ) );
+
+            break;
+        }
+    }
+
+    return structReturned;
+}

--- a/lib/FreeRTOS/freertos-plus-mqtt/agent_command_pool.c
+++ b/lib/FreeRTOS/freertos-plus-mqtt/agent_command_pool.c
@@ -112,7 +112,6 @@ Command_t * Agent_GetCommand( uint32_t blockTimeMs )
                     /* If the commandType is NONE then the structure is not in use. */
                     if( commandStructurePool[ i ].commandType == NONE )
                     {
-                        LogDebug( ( "Removed Command Context %d from pool", ( int ) i ) );
                         structToUse = &( commandStructurePool[ i ] );
 
                         /* To show the struct is no longer available to be returned

--- a/lib/FreeRTOS/freertos-plus-mqtt/agent_command_pool.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/agent_command_pool.h
@@ -1,0 +1,78 @@
+/*
+ * FreeRTOS V202011.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/**
+ * @file agent_command_pool.h
+ * @brief Functions to obtain and release a command.
+ */
+#ifndef AGENT_COMMAND_POOL_H
+#define AGENT_COMMAND_POOL_H
+
+/* MQTT agent includes. */
+#include "freertos_mqtt_agent.h"
+
+/**
+ * @brief Obtain a Command_t structure from the pool of structures managed by the agent.
+ *
+ * @note Command_t structures hold everything the MQTT agent needs to process a
+ * command that originates from application.  Examples of commands are PUBLISH and
+ * SUBSCRIBE.  The Command_t structure must persist for the duration of the command's
+ * operation so are obtained from a pool of statically allocated structures when a
+ * new command is created, and returned to the pool when the command is complete.
+ * The MQTT_COMMAND_CONTEXTS_POOL_SIZE configuration file constant defines how many
+ * structures the pool contains.
+ *
+ * @param[in] blockTimeMs The length of time the calling task should remain in the
+ * Blocked state (so not consuming any CPU time) to wait for a Command_t structure to
+ * become available should one not be immediately at the time of the call.
+ *
+ * @return A pointer to a Command_t structure if one becomes available before
+ * blockTimeMs time expired, otherwise NULL.
+ */
+Command_t * Agent_GetCommand( uint32_t blockTimeMs );
+
+/**
+ * @brief Give a Command_t structure back to the the pool of structures managed by
+ * the agent.
+ *
+ * @note Command_t structures hold everything the MQTT agent needs to process a
+ * command that originates from application.  Examples of commands are PUBLISH and
+ * SUBSCRIBE.  The Command_t structure must persist for the duration of the command's
+ * operation so are obtained from a pool of statically allocated structures when a
+ * new command is created, and returned to the pool when the command is complete.
+ * The MQTT_COMMAND_CONTEXTS_POOL_SIZE configuration file constant defines how many
+ * structures the pool contains.
+ *
+ * @param[in] pCommandToRelease A pointer to the Command_t structure to return to
+ * the pool.  The structure must first have been obtained by calling
+ * Agent_GetCommand(), otherwise Agent_ReleaseCommand() will
+ * have no effect.
+ *
+ * @return true if the Command_t structure was returned to the pool, otherwise false.
+ */
+bool Agent_ReleaseCommand( Command_t * pCommandToRelease );
+
+#endif /* AGENT_COMMAND_POOL_H */

--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.c
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.c
@@ -53,6 +53,7 @@
 
 /* MQTT agent include. */
 #include "freertos_mqtt_agent.h"
+#include "agent_command_pool.h"
 
 /*-----------------------------------------------------------*/
 
@@ -271,9 +272,6 @@ static MQTTAgentContext_t * getAgentFromMQTTContext( MQTTContext_t * pMQTTContex
  * @param[in] pCommandCompleteCallbackContext Context and necessary structs for command.
  * @param[in] cmdCompleteCallback Callback for when command completes.
  * @param[in] pMqttInfoParam Pointer to MQTTPublishInfo_t or MQTTSubscribeInfo_t.
- * @param[in] incomingPublishCallback Subscription callback function for incoming
- *            publishes.
- * @param[in] pIncomingPublishCallbackContext Subscription callback context.
  * @param[in] blockTimeMs Maximum amount of time in milliseconds to wait (in the
  * Blocked state, so not consuming any CPU time) for the command to be posted to the
  * MQTT agent should the MQTT agent's event queue be full.
@@ -286,51 +284,7 @@ static MQTTStatus_t createAndAddCommand( CommandType_t commandType,
                                          void * pMqttInfoParam,
                                          CommandCallback_t cmdCompleteCallback,
                                          CommandContext_t * pCommandCompleteCallbackContext,
-                                         IncomingPublishCallback_t incomingPublishCallback,
-                                         void * pIncomingPublishCallbackContext,
                                          uint32_t blockTimeMs );
-
-
-/**
- * @brief Obtain a Command_t structure from the pool of structures managed by the agent.
- *
- * @note Command_t structures hold everything the MQTT agent needs to process a
- * command that originates from application.  Examples of commands are PUBLISH and
- * SUBSCRIBE.  The Command_t structure must persist for the duration of the command's
- * operation so are obtained from a pool of statically allocated structures when a
- * new command is created, and returned to the pool when the command is complete.
- * The MQTT_COMMAND_CONTEXTS_POOL_SIZE configuration file constant defines how many
- * structures the pool contains.
- *
- * @param[in] blockTimeMs The length of time the calling task should remain in the
- * Blocked state (so not consuming any CPU time) to wait for a Command_t structure to
- * become available should one not be immediately at the time of the call.
- *
- * @return A pointer to a Command_t structure if one becomes available before
- * blockTimeMs time expired, otherwise NULL.
- */
-static Command_t * getCommandStructureFromPool( TickType_t blockTimeMs );
-
-/**
- * @brief Give a Command_t structure back to the the pool of structures managed by
- * the agent.
- *
- * @note Command_t structures hold everything the MQTT agent needs to process a
- * command that originates from application.  Examples of commands are PUBLISH and
- * SUBSCRIBE.  The Command_t structure must persist for the duration of the command's
- * operation so are obtained from a pool of statically allocated structures when a
- * new command is created, and returned to the pool when the command is complete.
- * The MQTT_COMMAND_CONTEXTS_POOL_SIZE configuration file constant defines how many
- * structures the pool contains.
- *
- * @param[in] pxCommandToRelease A pointer to the Command_t structure to return to
- * the pool.  The structure must first have been obtained by calling
- * getCommandStructureFromPool(), otherwise releaseCommandStructureToPool() will
- * have no effect.
- *
- * @return true if the Command_t structure was returned to the pool, otherwise false.
- */
-static bool releaseCommandStructureToPool( Command_t * pxCommandToRelease );
 
 /**
  * @brief Called before accepting any PUBLISH or SUBSCRIBE messages to check
@@ -353,105 +307,12 @@ static bool isSpaceInPendingAckList( MQTTAgentContext_t * pAgentContext );
 /*-----------------------------------------------------------*/
 
 /**
- * @brief The pool of command structures used to hold information on commands (such
- * as PUBLISH or SUBSCRIBE) between the command being created by an API call and
- * by either an error or the execution of the commands callback.
- */
-static Command_t commandStructurePool[ MQTT_COMMAND_CONTEXTS_POOL_SIZE ];
-
-/**
- * @brief A counting semaphore used to guard the pool of Command_t structures.  To
- * obtain a structure first decrement the semaphore count.  To return a structure
- * increment the semaphore count after the structure is back in the pool.
- */
-static SemaphoreHandle_t freeCommandStructMutex = NULL;
-
-/**
  * @brief Flag that is set to true in the application callback to let the agent know
  * that calling MQTT_ProcessLoop() resulted in events on the connected socket.  If
  * the flag gets set to true then MQTT_ProcessLoop() is called again as there may be
  * more received data waiting to be processed.
  */
 static bool packetProcessedDuringLoop = false;
-
-/*-----------------------------------------------------------*/
-
-static bool releaseCommandStructureToPool( Command_t * pxCommandToRelease )
-{
-    size_t i;
-    bool structReturned = false;
-
-    /* See if the structure being returned is actually from the pool. */
-    for( i = 0; i < MQTT_COMMAND_CONTEXTS_POOL_SIZE; i++ )
-    {
-        if( pxCommandToRelease == &( commandStructurePool[ i ] ) )
-        {
-            /* Yes its from the pool.  Clearing it to zero not only removes the old
-             * data it also sets the structure's commandType parameter to NONE to
-             * mark the structure as free again. */
-            memset( ( void * ) pxCommandToRelease, 0x00, sizeof( Command_t ) );
-
-            /* Give back the counting semaphore after returning the structure so the
-             * semaphore count equals the number of available structures. */
-            xSemaphoreGive( freeCommandStructMutex );
-            structReturned = true;
-
-            LogDebug( ( "Returned Command Context %d to pool", ( int ) i ) );
-
-            break;
-        }
-    }
-
-    return structReturned;
-}
-
-/*-----------------------------------------------------------*/
-
-static Command_t * getCommandStructureFromPool( TickType_t blockTimeMs )
-{
-    Command_t * structToUse = NULL;
-    size_t i;
-    static bool initialized = false;
-
-    if( !initialized )
-    {
-        memset( ( void * ) commandStructurePool, 0x00, sizeof( commandStructurePool ) );
-        freeCommandStructMutex = xSemaphoreCreateCounting( MQTT_COMMAND_CONTEXTS_POOL_SIZE, MQTT_COMMAND_CONTEXTS_POOL_SIZE );
-        configASSERT( freeCommandStructMutex ); /*_RB_ Create all objects here statically. */
-
-        initialized = true;
-    }
-
-    /* Check counting semaphore has been created. */
-    if( freeCommandStructMutex != NULL )
-    {
-        /* If the semaphore count is not zero then a command context is available. */
-        if( xSemaphoreTake( freeCommandStructMutex, pdMS_TO_TICKS( blockTimeMs ) ) == pdPASS )
-        {
-            for( i = 0; i < MQTT_COMMAND_CONTEXTS_POOL_SIZE; i++ )
-            {
-                taskENTER_CRITICAL();
-                {
-                    /* If the commandType is NONE then the structure is not in use. */
-                    if( commandStructurePool[ i ].commandType == NONE )
-                    {
-                        LogDebug( ( "Removed Command Context %d from pool", ( int ) i ) );
-                        structToUse = &( commandStructurePool[ i ] );
-
-                        /* To show the struct is no longer available to be returned
-                         * by calls to releaseCommandStructureToPool(). */
-                        structToUse->commandType = !NONE;
-                        taskEXIT_CRITICAL();
-                        break;
-                    }
-                }
-                taskEXIT_CRITICAL();
-            }
-        }
-    }
-
-    return structToUse;
-}
 
 /*-----------------------------------------------------------*/
 
@@ -841,7 +702,6 @@ static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
                 break;
 
             case CONNECT:
-                operationStatus = MQTTSuccess; //TODO I don't know why clangd dings the next line.
                 MQTTAgentConnectArgs_t * pConnectArgs = ( MQTTAgentConnectArgs_t * ) ( pCommand->pArgs );
                 operationStatus = MQTT_Connect( pMQTTContext,
                                                 pConnectArgs->pConnectInfo,
@@ -889,7 +749,7 @@ static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
                 pCommand->pCommandCompleteCallback( pCommand->pCmdContext, &returnInfo );
             }
 
-            releaseCommandStructureToPool( pCommand );
+            Agent_ReleaseCommand( pCommand );
         }
     }
 
@@ -1038,7 +898,7 @@ static void handleSubscriptionAcks( MQTTAgentContext_t * pAgentContext,
         ackCallback( pAckContext, &returnInfo );
     }
 
-    releaseCommandStructureToPool( pAckInfo->pOriginalCommand ); //_RB_ Is this always the right place for this?
+    Agent_ReleaseCommand( pAckInfo->pOriginalCommand ); //_RB_ Is this always the right place for this?
 }
 
 /*-----------------------------------------------------------*/
@@ -1101,7 +961,7 @@ static void mqttEventCallback( MQTTContext_t * pMqttContext,
                     }
                 }
 
-                releaseCommandStructureToPool( ackInfo.pOriginalCommand ); //_RB_ Is this always the right place for this?
+                Agent_ReleaseCommand( ackInfo.pOriginalCommand ); //_RB_ Is this always the right place for this?
                 break;
 
             case MQTT_PACKET_TYPE_SUBACK:
@@ -1151,8 +1011,6 @@ static MQTTStatus_t createAndAddCommand( CommandType_t commandType,
                                          void * pMqttInfoParam,
                                          CommandCallback_t commandCompleteCallback,
                                          CommandContext_t * pCommandCompleteCallbackContext,
-                                         IncomingPublishCallback_t incomingPublishCallback,
-                                         void * pIncomingPublishCallbackContext,
                                          uint32_t blockTimeMs )
 {
     MQTTStatus_t statusReturn = MQTTSuccess;
@@ -1162,7 +1020,7 @@ static MQTTStatus_t createAndAddCommand( CommandType_t commandType,
      * is the initial value but not a valid packet ID. */
     if( pMqttAgentContext->mqttContext.nextPacketId != 0 )
     {
-        pCommand = getCommandStructureFromPool( blockTimeMs );
+        pCommand = Agent_GetCommand( blockTimeMs );
 
         if( pCommand != NULL )
         {
@@ -1182,7 +1040,7 @@ static MQTTStatus_t createAndAddCommand( CommandType_t commandType,
             {
                 /* Could not send the command to the queue so release the command
                  * structure again. */
-                releaseCommandStructureToPool( pCommand );
+                Agent_ReleaseCommand( pCommand );
             }
         }
         else
@@ -1454,8 +1312,6 @@ MQTTStatus_t MQTTAgent_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
                                         pSubscriptionArgs,              /* pMqttInfoParam */
                                         pCommandInfo->cmdCompleteCallback,        /* commandCompleteCallback */
                                         pCommandInfo->pCmdCompleteCallbackContext, /* pCommandCompleteCallbackContext */
-                                        NULL,        /* incomingPublishCallback */
-                                        NULL, /* pIncomingPublishCallbackContext */
                                         pCommandInfo->blockTimeMs );
     return statusReturn;
 }
@@ -1473,8 +1329,6 @@ MQTTStatus_t MQTTAgent_Unsubscribe( MQTTAgentContext_t * pMqttAgentContext,
                                         pSubscriptionArgs,               /* pMqttInfoParam */
                                         pCommandInfo->cmdCompleteCallback,             /* commandCompleteCallback */
                                         pCommandInfo->pCmdCompleteCallbackContext, /* pCommandCompleteCallbackContext */
-                                        NULL,                            /* incomingPublishCallback */
-                                        NULL,                            /* pIncomingPublishCallbackContext */
                                         pCommandInfo->blockTimeMs );
 
     return statusReturn;
@@ -1493,8 +1347,6 @@ MQTTStatus_t MQTTAgent_Publish( MQTTAgentContext_t * pMqttAgentContext,
                                         pPublishInfo,                   /* pMqttInfoParam */
                                         pCommandInfo->cmdCompleteCallback,        /* commandCompleteCallback */
                                         pCommandInfo->pCmdCompleteCallbackContext, /* pCommandCompleteCallbackContext */
-                                        NULL,                           /* incomingPublishCallback */
-                                        NULL,                           /* pIncomingPublishCallbackContext */
                                         pCommandInfo->blockTimeMs );
 
     return statusReturn;
@@ -1512,8 +1364,6 @@ MQTTStatus_t MQTTAgent_TriggerProcessLoop( MQTTAgentContext_t * pMqttAgentContex
                                         NULL,              /* pMqttInfoParam */
                                         NULL,              /* commandCompleteCallback */
                                         NULL,              /* pCommandCompleteCallbackContext */
-                                        NULL,              /* incomingPublishCallback */
-                                        NULL,              /* pIncomingPublishCallbackContext */
                                         blockTimeMs );
 
     return statusReturn;
@@ -1531,8 +1381,6 @@ MQTTStatus_t MQTTAgent_Connect( MQTTAgentContext_t * pMqttAgentContext,
                                         pConnectArgs,
                                         pCommandInfo->cmdCompleteCallback,
                                         pCommandInfo->pCmdCompleteCallbackContext,
-                                        NULL,
-                                        NULL,
                                         pCommandInfo->blockTimeMs );
 
     return statusReturn;
@@ -1550,8 +1398,6 @@ MQTTStatus_t MQTTAgent_Disconnect( MQTTAgentContext_t * pMqttAgentContext,
                                         NULL,                   /* pMqttInfoParam */
                                         pCommandInfo->cmdCompleteCallback,        /* commandCompleteCallback */
                                         pCommandInfo->pCmdCompleteCallbackContext, /* pCommandCompleteCallbackContext */
-                                        NULL,                           /* incomingPublishCallback */
-                                        NULL,                           /* pIncomingPublishCallbackContext */
                                         pCommandInfo->blockTimeMs );
 
     return statusReturn;
@@ -1569,8 +1415,6 @@ MQTTStatus_t MQTTAgent_Ping( MQTTAgentContext_t * pMqttAgentContext,
                                         NULL,                   /* pMqttInfoParam */
                                         pCommandInfo->cmdCompleteCallback,        /* commandCompleteCallback */
                                         pCommandInfo->pCmdCompleteCallbackContext, /* pCommandCompleteCallbackContext */
-                                        NULL,                           /* incomingPublishCallback */
-                                        NULL,                           /* pIncomingPublishCallbackContext */
                                         pCommandInfo->blockTimeMs );
 
     return statusReturn;
@@ -1588,8 +1432,6 @@ MQTTStatus_t MQTTAgent_Terminate( MQTTAgentContext_t * pMqttAgentContext,
                                         NULL,
                                         pCommandInfo->cmdCompleteCallback,
                                         pCommandInfo->pCmdCompleteCallbackContext,
-                                        NULL,
-                                        NULL,
                                         pCommandInfo->blockTimeMs );
 
     return statusReturn;

--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.c
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.c
@@ -578,7 +578,7 @@ static MQTTStatus_t addCommandToQueue( AgentQueue_t * pQueue,
      * structure to the MQTT agent for processing. */
     if( pQueue != NULL )
     {
-        queueStatus = Agent_QueuePush( pQueue, &pCommand, blockTimeMs );
+        queueStatus = Agent_QueueSend( pQueue, &pCommand, blockTimeMs );
 
         statusReturn = ( queueStatus ) ? MQTTSuccess : MQTTSendFailed;
     }
@@ -1070,7 +1070,7 @@ MQTTStatus_t MQTTAgent_CommandLoop( MQTTAgentContext_t * pMqttAgentContext )
     {
         /* Wait for the next command, if any. */
         pCommand = NULL;
-        ( void ) Agent_QueuePop( pMqttAgentContext->commandQueue, &( pCommand ), MQTT_AGENT_MAX_EVENT_QUEUE_WAIT_TIME );
+        ( void ) Agent_QueueReceive( pMqttAgentContext->commandQueue, &( pCommand ), MQTT_AGENT_MAX_EVENT_QUEUE_WAIT_TIME );
         /* Set the command type in case the command is released while processing. */
         currentCommandType = ( pCommand ) ? pCommand->commandType : NONE;
         operationStatus = processCommand( pMqttAgentContext, pCommand );

--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.c
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.c
@@ -54,19 +54,6 @@
 
 /*-----------------------------------------------------------*/
 
-/**
- * @brief The commands sent from the publish API to the MQTT agent.
- *
- * @note The structure used to pass information from the public facing API into the
- * agent task. */
-struct Command
-{
-    CommandType_t commandType;
-    void * pArgs;
-    CommandCallback_t pCommandCompleteCallback;
-    CommandContext_t * pCmdContext;
-};
-
 #if 0
 
 /**

--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
@@ -100,25 +100,25 @@ typedef struct CommandContext CommandContext_t;
 /**
  * @brief Callback function called when a command completes.
  *
- * @param[in] The callback context passed to the original command.
- * @param[in] A struct of status codes and outputs from the command.
+ * @param[in] pCmdCallbackContext The callback context passed to the original command.
+ * @param[in] pReturnInfo A struct of status codes and outputs from the command.
  *
  * @note A command should not be considered complete until this callback is
  * called, and arguments the command needs MUST stay in scope until such happens.
  */
-typedef void (* CommandCallback_t )( void *,
-                                     MQTTAgentReturnInfo_t * );
+typedef void (* CommandCallback_t )( void * pCmdCallbackContext,
+                                     MQTTAgentReturnInfo_t * pReturnInfo );
 
 /**
  * @brief Callback function called when receiving a publish.
  *
- * @param[in] The context of the MQTT agent.
- * @param[in] The packet ID of the received publish.
- * @param[in] Deserialized publish information.
+ * @param[in] pMqttAgentContext The context of the MQTT agent.
+ * @param[in] packetId The packet ID of the received publish.
+ * @param[in] pxPublishInfo Deserialized publish information.
  */
 typedef void (* IncomingPublishCallback_t )( MQTTAgentContext_t * pMqttAgentContext,
                                              uint16_t packetId,
-                                             MQTTPublishInfo_t * pxPublishInfo );
+                                             MQTTPublishInfo_t * pPublishInfo );
 
 /* Temporary define before platform abstraction. */
 #define AgentQueue_t    void

--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
@@ -132,7 +132,7 @@ typedef void (* CommandCallback_t )( void * pCmdCallbackContext,
  *
  * @param[in] pMqttAgentContext The context of the MQTT agent.
  * @param[in] packetId The packet ID of the received publish.
- * @param[in] pxPublishInfo Deserialized publish information.
+ * @param[in] pPublishInfo Deserialized publish information.
  */
 typedef void (* IncomingPublishCallback_t )( MQTTAgentContext_t * pMqttAgentContext,
                                              uint16_t packetId,

--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
@@ -182,6 +182,19 @@ typedef struct CommandInfo
     uint32_t blockTimeMs;
 } CommandInfo_t;
 
+/**
+ * @brief The commands sent from the publish API to the MQTT agent.
+ *
+ * @note The structure used to pass information from the public facing API into the
+ * agent task. */
+struct Command
+{
+    CommandType_t commandType;
+    void * pArgs;
+    CommandCallback_t pCommandCompleteCallback;
+    CommandContext_t * pCmdContext;
+};
+
 /*-----------------------------------------------------------*/
 
 /**

--- a/lib/FreeRTOS/freertos-plus-mqtt/mqtt_agent_queue.c
+++ b/lib/FreeRTOS/freertos-plus-mqtt/mqtt_agent_queue.c
@@ -49,7 +49,7 @@ struct AgentQueue
 
 /*-----------------------------------------------------------*/
 
-bool Agent_QueuePush( const AgentQueue_t * pQueueHandle,
+bool Agent_QueueSend( const AgentQueue_t * pQueueHandle,
                       const void * pData,
                       uint32_t blockTimeMs )
 {
@@ -65,9 +65,9 @@ bool Agent_QueuePush( const AgentQueue_t * pQueueHandle,
 
 /*-----------------------------------------------------------*/
 
-bool Agent_QueuePop( const AgentQueue_t * pQueueHandle,
-                     void * pBuffer,
-                     uint32_t blockTimeMs )
+bool Agent_QueueReceive( const AgentQueue_t * pQueueHandle,
+                         void * pBuffer,
+                         uint32_t blockTimeMs )
 {
     BaseType_t queueStatus = pdFAIL;
 
@@ -76,5 +76,5 @@ bool Agent_QueuePop( const AgentQueue_t * pQueueHandle,
         queueStatus = xQueueReceive( pQueueHandle->queue, pBuffer, pdMS_TO_TICKS( blockTimeMs ) );
     }
 
-    return false;
+    return ( queueStatus == pdPASS ) ? true : false;
 }

--- a/lib/FreeRTOS/freertos-plus-mqtt/mqtt_agent_queue.c
+++ b/lib/FreeRTOS/freertos-plus-mqtt/mqtt_agent_queue.c
@@ -1,0 +1,80 @@
+/*
+ * FreeRTOS V202011.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/**
+ * @file mqtt_agent_queue.c
+ * @brief Implements functions to interact with queues.
+ */
+
+/* Standard includes. */
+#include <string.h>
+#include <stdio.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "semphr.h"
+
+/* Header include. */
+#include "mqtt_agent_queue.h"
+
+/*-----------------------------------------------------------*/
+
+struct AgentQueue
+{
+    QueueHandle_t queue;
+};
+
+/*-----------------------------------------------------------*/
+
+bool Agent_QueuePush( const AgentQueue_t * pQueueHandle,
+                      const void * pData,
+                      uint32_t blockTimeMs )
+{
+    BaseType_t queueStatus = pdFAIL;
+
+    if( ( pQueueHandle != NULL ) && ( pData != NULL ) )
+    {
+        queueStatus = xQueueSendToBack( pQueueHandle->queue, pData, pdMS_TO_TICKS( blockTimeMs ) );
+    }
+
+    return ( queueStatus == pdPASS ) ? true : false;
+}
+
+/*-----------------------------------------------------------*/
+
+bool Agent_QueuePop( const AgentQueue_t * pQueueHandle,
+                     void * pBuffer,
+                     uint32_t blockTimeMs )
+{
+    BaseType_t queueStatus = pdFAIL;
+
+    if( ( pQueueHandle != NULL ) && ( pBuffer != NULL ) )
+    {
+        queueStatus = xQueueReceive( pQueueHandle->queue, pBuffer, pdMS_TO_TICKS( blockTimeMs ) );
+    }
+
+    return false;
+}

--- a/lib/FreeRTOS/freertos-plus-mqtt/mqtt_agent_queue.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/mqtt_agent_queue.h
@@ -1,0 +1,71 @@
+/*
+ * FreeRTOS V202011.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/**
+ * @file mqtt_agent_queue.h
+ * @brief Functions to interact with queues.
+ */
+#ifndef MQTT_AGENT_QUEUE_H
+#define MQTT_AGENT_QUEUE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+struct AgentQueue;
+typedef struct AgentQueue AgentQueue_t;
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Send a message to the back of the specified queue.
+ * Must be thread safe.
+ *
+ * @param[in] pQueueHandle An #AgentQueue_t.
+ * @param[in] data Pointer to element to send to queue.
+ * @param[in] blockTimeMs Block time to wait for a send.
+ *
+ * @return `true` if send was successful, else `false`.
+ */
+bool Agent_QueuePush( const AgentQueue_t * pQueueHandle,
+                      const void * pData,
+                      uint32_t blockTimeMs );
+
+/**
+ * @brief Receive a message from the front of the specified queue.
+ * Must be thread safe.
+ *
+ * @param[in] pQueueHandle An #AgentQueue_t.
+ * @param[in] pBuffer Pointer to buffer to write received data.
+ * @param[in] blockTimeMs Block time to wait for a receive.
+ *
+ * @return `true` if receive was successful, else `false`.
+ */
+bool Agent_QueuePop( const AgentQueue_t * pQueueHandle,
+                     void * pBuffer,
+                     uint32_t blockTimeMs );
+
+#endif /* MQTT_AGENT_QUEUE_H */

--- a/lib/FreeRTOS/freertos-plus-mqtt/mqtt_agent_queue.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/mqtt_agent_queue.h
@@ -50,7 +50,7 @@ typedef struct AgentQueue AgentQueue_t;
  *
  * @return `true` if send was successful, else `false`.
  */
-bool Agent_QueuePush( const AgentQueue_t * pQueueHandle,
+bool Agent_QueueSend( const AgentQueue_t * pQueueHandle,
                       const void * pData,
                       uint32_t blockTimeMs );
 
@@ -64,8 +64,8 @@ bool Agent_QueuePush( const AgentQueue_t * pQueueHandle,
  *
  * @return `true` if receive was successful, else `false`.
  */
-bool Agent_QueuePop( const AgentQueue_t * pQueueHandle,
-                     void * pBuffer,
-                     uint32_t blockTimeMs );
+bool Agent_QueueReceive( const AgentQueue_t * pQueueHandle,
+                     	 void * pBuffer,
+                    	 uint32_t blockTimeMs );
 
 #endif /* MQTT_AGENT_QUEUE_H */


### PR DESCRIPTION
*Description*:

Separates the command pool and queue into their own files. This allows the agent to be more easily ported by separating out platform specific code, and allows the user to change the command retrieval method if they do not want to be constricted to using a pool.

