### PR TITLE
Update API doc of callbacks to suggest against calling agent API

### DIFF
--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
@@ -129,9 +129,6 @@ typedef struct CommandContext CommandContext_t;
  * blocking time (blockTimeMs member of CommandInfo_t) MUST be zero. If the
  * application wants to enqueue command(s) with non-zero blocking time, the
  * callback can notify a different task to enqueue command(s) to the MQTT agent.
- *
- * @note The context passed to the callback through the @p pCmdCallbackContext parameter
- * MUST remain in scope at least until the callback has been executed by the agent task.
  */
 typedef void (* CommandCallback_t )( void * pCmdCallbackContext,
                                      MQTTAgentReturnInfo_t * pReturnInfo );
@@ -276,6 +273,10 @@ MQTTStatus_t MQTTAgent_ResumeSession( MQTTAgentContext_t * pMqttAgentContext,
  *    command to be posted to the MQTT agent, should the agent's event queue
  *    be full. Tasks wait in the Blocked state so don't use any CPU time.
  *
+ * @note The context passed to the callback through pCmdContext member of
+ * @p pCommandInfo parameter MUST remain in scope at least until the callback
+ * has been executed by the agent task.
+ *
  * @return `MQTTSuccess` if the command was posted to the MQTT agents event queue.
  * Otherwise an enumerated error code.
  */
@@ -295,6 +296,10 @@ MQTTStatus_t MQTTAgent_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
  *    command to be posted to the MQTT agent, should the agent's event queue
  *    be full. Tasks wait in the Blocked state so don't use any CPU time.
  *
+ * @note The context passed to the callback through pCmdContext member of
+ * @p pCommandInfo parameter MUST remain in scope at least until the callback
+ * has been executed by the agent task.
+ *
  * @return `MQTTSuccess` if the command was posted to the MQTT agents event queue.
  * Otherwise an enumerated error code.
  */
@@ -313,6 +318,10 @@ MQTTStatus_t MQTTAgent_Unsubscribe( MQTTAgentContext_t * pMqttAgentContext,
  *  - blockTimeMs The maximum amount of time in milliseconds to wait for the
  *    command to be posted to the MQTT agent, should the agent's event queue
  *    be full. Tasks wait in the Blocked state so don't use any CPU time.
+ *
+ * @note The context passed to the callback through pCmdContext member of
+ * @p pCommandInfo parameter MUST remain in scope at least until the callback
+ * has been executed by the agent task.
  *
  * @return `MQTTSuccess` if the command was posted to the MQTT agents event queue.
  * Otherwise an enumerated error code.
@@ -349,6 +358,10 @@ MQTTStatus_t MQTTAgent_TriggerProcessLoop( MQTTAgentContext_t * pMqttAgentContex
  *    command to be posted to the MQTT agent, should the agent's event queue
  *    be full. Tasks wait in the Blocked state so don't use any CPU time.
  *
+ * @note The context passed to the callback through pCmdContext member of
+ * @p pCommandInfo parameter MUST remain in scope at least until the callback
+ * has been executed by the agent task.
+ *
  * @return `MQTTSuccess` if the command was posted to the MQTT agents event queue.
  * Otherwise an enumerated error code.
  */
@@ -368,6 +381,10 @@ MQTTStatus_t MQTTAgent_Ping( MQTTAgentContext_t * pMqttAgentContext,
  *    command to be posted to the MQTT agent, should the agent's event queue
  *    be full. Tasks wait in the Blocked state so don't use any CPU time.
  *
+ * @note The context passed to the callback through pCmdContext member of
+ * @p pCommandInfo parameter MUST remain in scope at least until the callback
+ * has been executed by the agent task.
+ *
  * @return `MQTTSuccess` if the command was posted to the MQTT agents event queue.
  * Otherwise an enumerated error code.
  */
@@ -386,6 +403,10 @@ MQTTStatus_t MQTTAgent_Connect( MQTTAgentContext_t * pMqttAgentContext,
  *    command to be posted to the MQTT agent, should the agent's event queue
  *    be full. Tasks wait in the Blocked state so don't use any CPU time.
  *
+ * @note The context passed to the callback through pCmdContext member of
+ * @p pCommandInfo parameter MUST remain in scope at least until the callback
+ * has been executed by the agent task.
+ *
  * @return `MQTTSuccess` if the command was posted to the MQTT agents event queue.
  * Otherwise an enumerated error code.
  */
@@ -402,6 +423,10 @@ MQTTStatus_t MQTTAgent_Disconnect( MQTTAgentContext_t * pMqttAgentContext,
  *  - blockTimeMs The maximum amount of time in milliseconds to wait for the
  *    command to be posted to the MQTT agent, should the agent's event queue
  *    be full. Tasks wait in the Blocked state so don't use any CPU time.
+ *
+ * @note The context passed to the callback through pCmdContext member of
+ * @p pCommandInfo parameter MUST remain in scope at least until the callback
+ * has been executed by the agent task.
  *
  * @return `MQTTSuccess` if the command was posted to the MQTT agents event queue.
  * Otherwise an enumerated error code.

--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
@@ -122,7 +122,12 @@ typedef struct CommandContext CommandContext_t;
  * @param[in] pReturnInfo A struct of status codes and outputs from the command.
  *
  * @note A command should not be considered complete until this callback is
- * called, and arguments the command needs MUST stay in scope until such happens.
+ * called, and the arguments that the command uses MUST stay in scope until such happens.
+ *
+ * @note As this callback is run in the task context of the MQTT agent, a command
+ * SHOULD NOT be queued to the agent from within the callback. If the application
+ * sequence wants to queue a command as an effect of executing this callback, this
+ * callback should notify a different task to enqueue commands to the MQTT agent.
  */
 typedef void (* CommandCallback_t )( void * pCmdCallbackContext,
                                      MQTTAgentReturnInfo_t * pReturnInfo );
@@ -133,6 +138,14 @@ typedef void (* CommandCallback_t )( void * pCmdCallbackContext,
  * @param[in] pMqttAgentContext The context of the MQTT agent.
  * @param[in] packetId The packet ID of the received publish.
  * @param[in] pPublishInfo Deserialized publish information.
+ *
+ * @note As this callback is run in the task context of the MQTT agent, a command
+ * SHOULD NOT be queued to the agent from within the callback. If the application
+ * sequence wants to queue a command as an effect of executing this callback, this
+ * callback should notify a different task to enqueue commands to the MQTT agent.
+ *
+ * @note The context passed to the callback through the @p agentContext parameter
+ * MUST remain in scope throughtout the period that the agent task is running.
  */
 typedef void (* IncomingPublishCallback_t )( MQTTAgentContext_t * pMqttAgentContext,
                                              uint16_t packetId,
@@ -184,7 +197,7 @@ typedef struct CommandInfo
 } CommandInfo_t;
 
 /**
- * @brief The commands sent from the publish API to the MQTT agent.
+ * @brief The commands sent from the APIs to the MQTT agent task.
  *
  * @note The structure used to pass information from the public facing API into the
  * agent task. */

--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
@@ -144,8 +144,8 @@ typedef void (* CommandCallback_t )( void * pCmdCallbackContext,
  * sequence wants to queue a command as an effect of executing this callback, this
  * callback should notify a different task to enqueue commands to the MQTT agent.
  *
- * @note The context passed to the callback through the @p agentContext parameter
- * MUST remain in scope throughtout the period that the agent task is running.
+ * @note The context passed to the callback through the @p pMqttAgentContext parameter
+ * MUST remain in scope throughout the period that the agent task is running.
  */
 typedef void (* IncomingPublishCallback_t )( MQTTAgentContext_t * pMqttAgentContext,
                                              uint16_t packetId,

--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
@@ -124,10 +124,14 @@ typedef struct CommandContext CommandContext_t;
  * @note A command should not be considered complete until this callback is
  * called, and the arguments that the command uses MUST stay in scope until such happens.
  *
- * @note As this callback is run in the task context of the MQTT agent, a command
- * SHOULD NOT be queued to the agent from within the callback. If the application
- * sequence wants to queue a command as an effect of executing this callback, this
- * callback should notify a different task to enqueue commands to the MQTT agent.
+ * @note The callback MUST NOT block as it runs in the context of the MQTT agent
+ * task. If the callback calls any MQTT Agent API to enqueue a command, the
+ * blocking time (blockTimeMs member of CommandInfo_t) MUST be zero. If the
+ * application wants to enqueue command(s) with non-zero blocking time, the
+ * callback can notify a different task to enqueue command(s) to the MQTT agent.
+ *
+ * @note The context passed to the callback through the @p pCmdCallbackContext parameter
+ * MUST remain in scope at least until the callback has been executed by the agent task.
  */
 typedef void (* CommandCallback_t )( void * pCmdCallbackContext,
                                      MQTTAgentReturnInfo_t * pReturnInfo );
@@ -139,10 +143,11 @@ typedef void (* CommandCallback_t )( void * pCmdCallbackContext,
  * @param[in] packetId The packet ID of the received publish.
  * @param[in] pPublishInfo Deserialized publish information.
  *
- * @note As this callback is run in the task context of the MQTT agent, a command
- * SHOULD NOT be queued to the agent from within the callback. If the application
- * sequence wants to queue a command as an effect of executing this callback, this
- * callback should notify a different task to enqueue commands to the MQTT agent.
+ * @note The callback MUST NOT block as it runs in the context of the MQTT agent
+ * task. If the callback calls any MQTT Agent API to enqueue a command, the
+ * blocking time (blockTimeMs member of CommandInfo_t) MUST be zero. If the
+ * application wants to enqueue command(s) with non-zero blocking time, the
+ * callback can notify a different task to enqueue command(s) to the MQTT agent.
  *
  * @note The context passed to the callback through the @p pMqttAgentContext parameter
  * MUST remain in scope throughout the period that the agent task is running.
@@ -225,6 +230,9 @@ struct Command
  * @param[in] incomingCallback The callback to execute when receiving publishes.
  * @param[in] pIncomingPacketContext A pointer to a context structure defined by
  * the application writer.
+ *
+ * @note The @p pIncomingPacketContext context provided for the incoming publish
+ * callback MUST remain in scope throughout the period that the agent task is running.
  *
  * @return Appropriate status code from MQTT_Init().
  */

--- a/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
+++ b/lib/FreeRTOS/freertos-plus-mqtt/freertos_mqtt_agent.h
@@ -148,9 +148,6 @@ typedef void (* CommandCallback_t )( void * pCmdCallbackContext,
  * blocking time (blockTimeMs member of CommandInfo_t) MUST be zero. If the
  * application wants to enqueue command(s) with non-zero blocking time, the
  * callback can notify a different task to enqueue command(s) to the MQTT agent.
- *
- * @note The context passed to the callback through the @p pMqttAgentContext parameter
- * MUST remain in scope throughout the period that the agent task is running.
  */
 typedef void (* IncomingPublishCallback_t )( MQTTAgentContext_t * pMqttAgentContext,
                                              uint16_t packetId,


### PR DESCRIPTION
Update API documentation of MQTT agent callbacks to recommend against enqueing commands to the agent from within the callbacks. Reason: The callbacks run within the context of the MQTT agent task, and thus, either of the following issues can occur: 
* If the queue is full during the execution of the callback, a new command attempted to be queued (to the MQTT agent) from wthin the callback  will fail. 
* If the callback is successful in queueing a command to the agent (due to availability in queue), but if it waits for the completion command callback to be executed, then the wait operation would fail as the new command queue will not execute until the callback execution terminates.