### PR TITLE
Fix command struct pool

### DIFF
--- a/lib/FreeRTOS/freertos-plus-mqtt/agent_command_pool.c
+++ b/lib/FreeRTOS/freertos-plus-mqtt/agent_command_pool.c
@@ -60,7 +60,7 @@ static Command_t commandStructurePool[ MQTT_COMMAND_CONTEXTS_POOL_SIZE ];
 static SemaphoreHandle_t commandSems[ MQTT_COMMAND_CONTEXTS_POOL_SIZE ];
 
 /**
- * @brief Initialization status of the queue.
+ * @brief Initialization status of the command semaphore array.
  */
 static volatile uint8_t initStatus = SEMAPHORES_NOT_INITIALIZED;
 

--- a/source/subscription-manager/subscription_manager.c
+++ b/source/subscription-manager/subscription_manager.c
@@ -135,7 +135,7 @@ bool handleIncomingPublishes( SubscriptionElement_t * pxSubscriptionList,
                               MQTTPublishInfo_t * pxPublishInfo )
 {
     int32_t lIndex = 0;
-    bool isMatched = false;
+    bool isMatched = false, publishHandled = false;
 
     if( ( pxSubscriptionList == NULL ) ||
         ( pxPublishInfo == NULL ) )
@@ -160,10 +160,11 @@ bool handleIncomingPublishes( SubscriptionElement_t * pxSubscriptionList,
                 {
                     pxSubscriptionList[ lIndex ].pxIncomingPublishCallback( pxSubscriptionList[ lIndex ].pvIncomingPublishCallbackContext,
                                                                             pxPublishInfo );
+                    publishHandled = true;
                 }
             }
         }
     }
 
-    return isMatched;
+    return publishHandled;
 }


### PR DESCRIPTION
*Description*:
There is a race condition in the current command pool implementation, as it considers any zeroed command to be free, yet the agent also zeroes out commands before assigning them. This replaces the semaphore and zero checks of the command pool with a ~queue; commands are obtained by receiving a pointer from the queue, and released by adding the pointer back.~ array of binary semaphores, with one semaphore protecting access to each command

Also fixes a bug in the subscription manager that incorrectly reported status with > 1 subscription