### PR TITLE
Set configNETWORK_INTERFACE_TO_USE to 0L

### DIFF
--- a/source/configuration-files/FreeRTOSConfig.h
+++ b/source/configuration-files/FreeRTOSConfig.h
@@ -137,7 +137,7 @@
  * results in the wired network being used, while setting
  * configNETWORK_INTERFACE_TO_USE to 2 results in the wireless network being
  * used. */
-#define configNETWORK_INTERFACE_TO_USE      ( 5L ) /* 6 for virtual box */
+#define configNETWORK_INTERFACE_TO_USE      ( 0L )
 
 /* The address to which logging is sent should UDP logging be enabled. */
 #define configUDP_LOGGING_ADDR0             192


### PR DESCRIPTION
Sets the default value of configNETWORK_INTERFACE_TO_USE to 0L so user gets notice to change it to correct value for their machine.