### PR TITLE
Make MQTT functions configurable

### DIFF
--- a/build/VisualStudio/WIN32.vcxproj
+++ b/build/VisualStudio/WIN32.vcxproj
@@ -35,6 +35,7 @@
     <ClCompile Include="..\..\lib\FreeRTOS\mqtt-agent\coreMQTT\source\core_mqtt_state.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\mqtt-agent\mqtt_agent.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\mqtt-agent\agent_message.c" />
+    <ClCompile Include="..\..\lib\FreeRTOS\mqtt-agent\mqtt_agent_command_functions.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-tcp\FreeRTOS_ARP.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-tcp\FreeRTOS_DHCP.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-plus-tcp\FreeRTOS_DNS.c" />
@@ -97,6 +98,7 @@
     <ClInclude Include="..\..\lib\FreeRTOS\mqtt-agent\coreMQTT\source\interface\transport_interface.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\mqtt-agent\mqtt_agent.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\mqtt-agent\agent_message.h" />
+    <ClInclude Include="..\..\lib\FreeRTOS\mqtt-agent\mqtt_agent_command_functions.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-tcp\include\FreeRTOSIPConfigDefaults.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-tcp\include\FreeRTOS_ARP.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-tcp\include\FreeRTOS_DHCP.h" />

--- a/build/VisualStudio/WIN32.vcxproj.filters
+++ b/build/VisualStudio/WIN32.vcxproj.filters
@@ -318,6 +318,9 @@
     <ClCompile Include="..\..\lib\FreeRTOS\mqtt-agent\agent_message.c">
       <Filter>Lib\FreeRTOS\MQTT-Agent</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\lib\FreeRTOS\mqtt-agent\mqtt_agent_command_functions.c">
+      <Filter>Lib\FreeRTOS\MQTT-Agent</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\source\defender_demo.c">
       <Filter>Source</Filter>
     </ClCompile>
@@ -507,6 +510,9 @@
       <Filter>Lib\FreeRTOS\MQTT-Agent</Filter>
     </ClInclude>
     <ClInclude Include="..\..\lib\FreeRTOS\mqtt-agent\agent_message.h">
+      <Filter>Lib\FreeRTOS\MQTT-Agent</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\FreeRTOS\mqtt-agent\mqtt_agent_command_functions.h">
       <Filter>Lib\FreeRTOS\MQTT-Agent</Filter>
     </ClInclude>
     <ClInclude Include="..\..\source\defender-tools\metrics_collector.h">

--- a/lib/FreeRTOS/mqtt-agent/mqtt_agent.c
+++ b/lib/FreeRTOS/mqtt-agent/mqtt_agent.c
@@ -472,7 +472,7 @@ static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
     MQTTAgentReturnInfo_t returnInfo = { 0 };
     MQTTAgentCommandFunc_t commandFunction = NULL;
     void * pCommandArgs = NULL;
-    const uint32_t processLoopTimeoutMs = 0;
+    const uint32_t processLoopTimeoutMs = 0U;
     uint8_t commandOutFlags = 0U;
     MQTTAgentCommandFuncReturns_t commandOutParams = { 0 };
 

--- a/lib/FreeRTOS/mqtt-agent/mqtt_agent.c
+++ b/lib/FreeRTOS/mqtt-agent/mqtt_agent.c
@@ -51,6 +51,11 @@
 /* MQTT agent include. */
 #include "mqtt_agent.h"
 #include "agent_command_pool.h"
+#include "mqtt_agent_command_functions.h"
+
+/*-----------------------------------------------------------*/
+
+const MQTTAgentCommandFunc_t pCommandFunctionTable[ NUM_COMMANDS ] = MQTT_AGENT_FUNCTION_TABLE;
 
 /*-----------------------------------------------------------*/
 
@@ -127,11 +132,13 @@ static MQTTStatus_t addCommandToQueue( AgentMessageContext_t * pQueue,
  *
  * @param[in] pMqttAgentContext Agent context for MQTT connection.
  * @param[in] pCommand Pointer to command to process.
+ * @param[out] pEndLoop Whether the command loop should terminate.
  *
  * @return status of MQTT library API call.
  */
 static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
-                                    Command_t * pCommand );
+                                    Command_t * pCommand,
+                                    bool * pEndLoop );
 
 /**
  * @brief Dispatch incoming publishes and acks to their various handler functions.
@@ -457,144 +464,64 @@ static MQTTStatus_t addCommandToQueue( AgentMessageContext_t * pQueue,
 /*-----------------------------------------------------------*/
 
 static MQTTStatus_t processCommand( MQTTAgentContext_t * pMqttAgentContext,
-                                    Command_t * pCommand ) /*_RB_ Break up into sub-functions. */
+                                    Command_t * pCommand,
+                                    bool * pEndLoop )
 {
     MQTTStatus_t operationStatus = MQTTSuccess;
-    uint16_t packetId = MQTT_PACKET_ID_INVALID;
-    bool addAckToList = false, ackAdded = false;
-    MQTTPublishInfo_t * pPublishInfo;
-    MQTTAgentSubscribeArgs_t * pSubscribeArgs;
-    MQTTContext_t * pMQTTContext;
-    bool runProcessLoops = true;
-    const uint32_t processLoopTimeoutMs = 0;
+    bool ackAdded = false;
     MQTTAgentReturnInfo_t returnInfo = { 0 };
-    MQTTAgentConnectArgs_t * pConnectArgs = NULL;
+    MQTTAgentCommandFunc_t commandFunction = NULL;
+    void * pCommandArgs = NULL;
+    uint8_t commandOutFlags = 0U;
+    MQTTAgentCommandFuncReturns_t commandOutParams = { 0 };
 
     assert( pMqttAgentContext != NULL );
+    assert( pEndLoop != NULL );
 
     pMQTTContext = &( pMqttAgentContext->mqttContext );
 
     if( pCommand != NULL )
     {
-        switch( pCommand->commandType )
-        {
-            case PUBLISH:
-                pPublishInfo = ( MQTTPublishInfo_t * ) ( pCommand->pArgs );
+        commandFunction = pCommandFunctionTable[ pCommand->commandType ];
+        pCommandArgs = pCommand->pArgs;
+    }
+    else
+    {
+        commandFunction = pCommandFunctionTable[ NONE ];
+    }
 
-                if( pPublishInfo->qos != MQTTQoS0 )
-                {
-                    packetId = MQTT_GetPacketId( pMQTTContext );
-                }
+    operationStatus = commandFunction( pMqttAgentContext, pCommandArgs, &commandOutParams );
 
-                LogInfo( ( "Publishing message to %.*s.\n", ( int ) pPublishInfo->topicNameLength, pPublishInfo->pTopicName ) );
-                operationStatus = MQTT_Publish( pMQTTContext, pPublishInfo, packetId );
+    if( commandOutParams.addAcknowledgment )
+    {
+        ackAdded = addAwaitingOperation( pMqttAgentContext, commandOutParams.packetId, pCommand );
 
-                /* Add to pending ack list, or call callback if QoS 0. */
-                addAckToList = ( pPublishInfo->qos != MQTTQoS0 ) && ( operationStatus == MQTTSuccess );
-
-                break;
-
-            case SUBSCRIBE:
-            case UNSUBSCRIBE:
-                pSubscribeArgs = ( MQTTAgentSubscribeArgs_t * ) ( pCommand->pArgs );
-                packetId = MQTT_GetPacketId( pMQTTContext );
-
-                if( pCommand->commandType == SUBSCRIBE )
-                {
-                    /* Even if some subscriptions already exist in the subscription list,
-                     * it is fine to send another subscription request. A valid use case
-                     * for this is changing the maximum QoS of the subscription. */
-                    operationStatus = MQTT_Subscribe( pMQTTContext,
-                                                      pSubscribeArgs->pSubscribeInfo,
-                                                      pSubscribeArgs->numSubscriptions,
-                                                      packetId );
-                }
-                else
-                {
-                    operationStatus = MQTT_Unsubscribe( pMQTTContext,
-                                                        pSubscribeArgs->pSubscribeInfo,
-                                                        pSubscribeArgs->numSubscriptions,
-                                                        packetId );
-                }
-
-                addAckToList = ( operationStatus == MQTTSuccess );
-                break;
-
-            case PING:
-                operationStatus = MQTT_Ping( pMQTTContext );
-
-                break;
-
-            case CONNECT:
-                pConnectArgs = ( MQTTAgentConnectArgs_t * ) ( pCommand->pArgs );
-                operationStatus = MQTT_Connect( pMQTTContext,
-                                                pConnectArgs->pConnectInfo,
-                                                pConnectArgs->pWillInfo,
-                                                pConnectArgs->timeoutMs,
-                                                &( pConnectArgs->sessionPresent ) );
-                break;
-
-            case DISCONNECT:
-                operationStatus = MQTT_Disconnect( pMQTTContext );
-                runProcessLoops = false;
-
-                break;
-
-            case TERMINATE:
-                LogInfo( ( "Terminating command loop.\n" ) );
-                runProcessLoops = false;
-
-            default:
-                break;
-        }
-
-        if( addAckToList )
-        {
-            ackAdded = addAwaitingOperation( pMqttAgentContext, packetId, pCommand );
-
-            /* Set the return status if no memory was available to store the operation
-             * information. */
-            if( !ackAdded )
-            {
-                LogError( ( "No memory to wait for acknowledgment for packet %u\n", packetId ) );
-
-                /* All operations that can wait for acks (publish, subscribe,
-                 * unsubscribe) require a context. */
-                operationStatus = MQTTNoMemory;
-            }
-        }
-
+        /* Set the return status if no memory was available to store the operation
+         * information. */
         if( !ackAdded )
         {
-            /* The command is complete, call the callback. */
-            if( pCommand->pCommandCompleteCallback != NULL )
-            {
-                returnInfo.returnCode = operationStatus;
-                pCommand->pCommandCompleteCallback( pCommand->pCmdContext, &returnInfo );
-            }
+            LogError( ( "No memory to wait for acknowledgment for packet %u\n", commandOutParams.packetId ) );
 
-            Agent_ReleaseCommand( pCommand );
+            /* All operations that can wait for acks (publish, subscribe,
+             * unsubscribe) require a context. */
+            operationStatus = MQTTNoMemory;
         }
     }
 
-    /* Don't run process loops if there was an error or disconnect. */
-    runProcessLoops = ( operationStatus != MQTTSuccess ) ? false : runProcessLoops;
-
-    /* Run the process loop if there were no errors and the MQTT connection
-     * still exists. */
-    if( runProcessLoops )
+    if( ( pCommand != NULL ) && ( ackAdded != true ) )
     {
-        do
+        /* The command is complete, call the callback. */
+        if( pCommand->pCommandCompleteCallback != NULL )
         {
-            pMqttAgentContext->packetReceivedInLoop = false;
+            returnInfo.returnCode = operationStatus;
+            pCommand->pCommandCompleteCallback( pCommand->pCmdContext, &returnInfo );
+        }
 
-            if( ( operationStatus == MQTTSuccess ) &&
-                ( pMQTTContext->connectStatus == MQTTConnected ) )
-            {
-                operationStatus = MQTT_ProcessLoop( pMQTTContext, processLoopTimeoutMs );
-            }
-        } while( pMqttAgentContext->packetReceivedInLoop );
+        Agent_ReleaseCommand( pCommand );
     }
+
+    /* Set the flag to break from the command loop. */
+    pEndLoop = ( commandOutParams.endLoop || ( operationStatus != MQTTSuccess ) );
 
     return operationStatus;
 }
@@ -814,6 +741,7 @@ MQTTStatus_t MQTTAgent_CommandLoop( MQTTAgentContext_t * pMqttAgentContext )
     Command_t * pCommand;
     MQTTStatus_t operationStatus = MQTTSuccess;
     CommandType_t currentCommandType = NONE;
+    bool endLoop = false;
 
     /* The command queue should have been created before this task gets created. */
     assert( pMqttAgentContext->pMessageCtx );
@@ -831,22 +759,16 @@ MQTTStatus_t MQTTAgent_CommandLoop( MQTTAgentContext_t * pMqttAgentContext )
         ( void ) Agent_MessageReceive( pMqttAgentContext->pMessageCtx, &( pCommand ), MQTT_AGENT_MAX_EVENT_QUEUE_WAIT_TIME );
         /* Set the command type in case the command is released while processing. */
         currentCommandType = ( pCommand ) ? pCommand->commandType : NONE;
-        operationStatus = processCommand( pMqttAgentContext, pCommand );
+        operationStatus = processCommand( pMqttAgentContext, pCommand, &endLoop );
 
-        /* Return the current MQTT context on disconnect or error. */
-        if( ( currentCommandType == DISCONNECT ) || ( operationStatus != MQTTSuccess ) )
+        if( operationStatus != MQTTSuccess )
         {
-            if( operationStatus != MQTTSuccess )
-            {
-                LogError( ( "MQTT operation failed with status %s\n",
-                            MQTT_Status_strerror( operationStatus ) ) );
-            }
-
-            break;
+            LogError( ( "MQTT operation failed with status %s\n",
+                        MQTT_Status_strerror( operationStatus ) ) );
         }
 
-        /* Terminate the loop if we receive the termination command. */
-        if( currentCommandType == TERMINATE )
+        /* Terminate the loop on disconnects, errors, or the termination command. */
+        if( endLoop )
         {
             break;
         }

--- a/lib/FreeRTOS/mqtt-agent/mqtt_agent.h
+++ b/lib/FreeRTOS/mqtt-agent/mqtt_agent.h
@@ -79,7 +79,8 @@ typedef enum CommandType
     PING,        /**< @brief Call MQTT_Ping(). */
     CONNECT,     /**< @brief Call MQTT_Connect(). */
     DISCONNECT,  /**< @brief Call MQTT_Disconnect(). */
-    TERMINATE    /**< @brief Exit the command loop and stop processing commands. */
+    TERMINATE,   /**< @brief Exit the command loop and stop processing commands. */
+    NUM_COMMANDS /**< @brief The number of command types handled by the agent. */
 } CommandType_t;
 
 struct MQTTAgentContext;

--- a/lib/FreeRTOS/mqtt-agent/mqtt_agent_command_functions.c
+++ b/lib/FreeRTOS/mqtt-agent/mqtt_agent_command_functions.c
@@ -42,29 +42,6 @@
 
 /*-----------------------------------------------------------*/
 
-static MQTTStatus_t runProcessLoops( MQTTAgentContext_t * pMqttAgentContext )
-{
-    MQTTStatus_t ret = MQTTSuccess;
-    const uint32_t processLoopTimeoutMs = 0;
-
-    assert( pMqttAgentContext != NULL );
-
-    do
-    {
-        pMqttAgentContext->packetReceivedInLoop = false;
-
-        if( ( ret == MQTTSuccess ) &&
-            ( pMqttAgentContext->mqttContext.connectStatus == MQTTConnected ) )
-        {
-            ret = MQTT_ProcessLoop( &( pMqttAgentContext->mqttContext ), processLoopTimeoutMs );
-        }
-    } while( pMqttAgentContext->packetReceivedInLoop );
-
-    return ret;
-}
-
-/*-----------------------------------------------------------*/
-
 MQTTStatus_t MQTTAgentCommand_ProcessLoop( MQTTAgentContext_t * pMqttAgentContext,
                                            void * pUnusedArg,
                                            MQTTAgentCommandFuncReturns_t * pReturnFlags )
@@ -291,3 +268,5 @@ MQTTStatus_t MQTTAgentCommand_Terminate( MQTTAgentContext_t * pMqttAgentContext,
 
     return MQTTSuccess;
 }
+
+/*-----------------------------------------------------------*/

--- a/lib/FreeRTOS/mqtt-agent/mqtt_agent_command_functions.c
+++ b/lib/FreeRTOS/mqtt-agent/mqtt_agent_command_functions.c
@@ -1,0 +1,308 @@
+/*
+ * FreeRTOS V202011.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/**
+ * @file mqtt_agent_command_functions.c
+ * @brief Implements functions to process MQTT agent commands.
+ */
+
+/* Standard includes. */
+#include <string.h>
+#include <stdio.h>
+#include <assert.h>
+
+/* MQTT agent include. */
+#include "mqtt_agent.h"
+
+/* Header include. */
+#include "mqtt_agent_command_functions.h"
+
+/*-----------------------------------------------------------*/
+
+static MQTTStatus_t runProcessLoops( MQTTAgentContext_t * pMqttAgentContext )
+{
+    MQTTStatus_t ret = MQTTSuccess;
+    const uint32_t processLoopTimeoutMs = 0;
+
+    assert( pMqttAgentContext != NULL );
+
+    do
+    {
+        pMqttAgentContext->packetReceivedInLoop = false;
+
+        if( ( ret == MQTTSuccess ) &&
+            ( pMqttAgentContext->mqttContext.connectStatus == MQTTConnected ) )
+        {
+            ret = MQTT_ProcessLoop( &( pMqttAgentContext->mqttContext ), processLoopTimeoutMs );
+        }
+    } while( pMqttAgentContext->packetReceivedInLoop );
+
+    return ret;
+}
+
+
+
+/*-----------------------------------------------------------*/
+
+MQTTStatus_t MQTTAgentCommand_ProcessLoop( MQTTAgentContext_t * pMqttAgentContext,
+                                           void * pUnusedArg,
+                                           MQTTAgentCommandFuncReturns_t * pReturnFlags )
+{
+    ( void ) pUnusedArg;
+    assert( pReturnFlags != NULL );
+
+    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+
+    return runProcessLoops( pMqttAgentContext );
+}
+
+/*-----------------------------------------------------------*/
+
+MQTTStatus_t MQTTAgentCommand_Publish( MQTTAgentContext_t * pMqttAgentContext,
+                                       void * pPublishArg,
+                                       MQTTAgentCommandFuncReturns_t * pReturnFlags )
+{
+    MQTTPublishInfo_t * pPublishInfo;
+    MQTTStatus_t ret;
+    uint16_t packetId;
+
+    assert( pMqttAgentContext != NULL );
+    assert( pPublishArg != NULL );
+    assert( pReturnFlags != NULL );
+
+    pPublishInfo = ( MQTTPublishInfo_t * ) ( pPublishArg );
+
+    if( pPublishInfo->qos != MQTTQoS0 )
+    {
+        pReturnFlags->packetId = MQTT_GetPacketId( &( pMqttAgentContext->mqttContext ) );
+    }
+
+    LogInfo( ( "Publishing message to %.*s.\n", ( int ) pPublishInfo->topicNameLength, pPublishInfo->pTopicName ) );
+    ret = MQTT_Publish( &( pMqttAgentContext->mqttContext ), pPublishInfo, pReturnFlags->packetId );
+
+    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+
+    /* Add to pending ack list, or call callback if QoS 0. */
+    pReturnFlags->addAcknowledgment = ( pPublishInfo->qos != MQTTQoS0 ) && ( ret == MQTTSuccess );
+
+    if( ret == MQTTSuccess )
+    {
+        ret = runProcessLoops( pMqttAgentContext );
+
+        if( ret != MQTTSuccess )
+        {
+            pReturnFlags->addAcknowledgment = false;
+        }
+    }
+
+    return ret;
+}
+
+/*-----------------------------------------------------------*/
+
+MQTTStatus_t MQTTAgentCommand_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
+                                         void * pSubscribeArgs,
+                                         MQTTAgentCommandFuncReturns_t * pReturnFlags )
+{
+    MQTTAgentSubscribeArgs_t * pSubscribeInfo;
+    MQTTStatus_t ret;
+    uint16_t packetId;
+
+    assert( pMqttAgentContext != NULL );
+    assert( pSubscribeArgs != NULL );
+    assert( pReturnFlags != NULL );
+
+    pSubscribeInfo = ( MQTTAgentSubscribeArgs_t * ) ( pSubscribeArgs );
+    pReturnFlags->packetId = MQTT_GetPacketId( &( pMqttAgentContext->mqttContext ) );
+
+    ret = MQTT_Subscribe( &( pMqttAgentContext->mqttContext ),
+                          pSubscribeInfo->pSubscribeInfo,
+                          pSubscribeInfo->numSubscriptions,
+                          pReturnFlags->packetId );
+
+    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+
+    if( ret == MQTTSuccess )
+    {
+        pReturnFlags->addAcknowledgment = true;
+        ret = runProcessLoops( pMqttAgentContext );
+
+        if( ret != MQTTSuccess )
+        {
+            pReturnFlags->addAcknowledgment = false;
+        }
+    }
+
+    return ret;
+}
+
+/*-----------------------------------------------------------*/
+
+MQTTStatus_t MQTTAgentCommand_Unsubscribe( MQTTAgentContext_t * pMqttAgentContext,
+                                           void * pSubscribeArgs,
+                                           MQTTAgentCommandFuncReturns_t * pReturnFlags )
+{
+    MQTTAgentSubscribeArgs_t * pSubscribeInfo;
+    MQTTStatus_t ret;
+    uint16_t packetId;
+
+    assert( pMqttAgentContext != NULL );
+    assert( pSubscribeArgs != NULL );
+    assert( pReturnFlags != NULL );
+
+    pSubscribeInfo = ( MQTTAgentSubscribeArgs_t * ) ( pSubscribeArgs );
+    pReturnFlags->packetId = MQTT_GetPacketId( &( pMqttAgentContext->mqttContext ) );
+
+    ret = MQTT_Unsubscribe( &( pMqttAgentContext->mqttContext ),
+                            pSubscribeInfo->pSubscribeInfo,
+                            pSubscribeInfo->numSubscriptions,
+                            pReturnFlags->packetId );
+
+    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+
+    if( ret == MQTTSuccess )
+    {
+        pReturnFlags->addAcknowledgment = true;
+        ret = runProcessLoops( pMqttAgentContext );
+
+        if( ret != MQTTSuccess )
+        {
+            pReturnFlags->addAcknowledgment = false;
+        }
+    }
+
+    return ret;
+}
+
+/*-----------------------------------------------------------*/
+
+MQTTStatus_t MQTTAgentCommand_Connect( MQTTAgentContext_t * pMqttAgentContext,
+                                       void * pConnectArgs,
+                                       MQTTAgentCommandFuncReturns_t * pReturnFlags )
+{
+    MQTTStatus_t ret;
+    MQTTAgentConnectArgs_t * pConnectInfo;
+
+    assert( pMqttAgentContext != NULL );
+    assert( pConnectArgs != NULL );
+    assert( pReturnFlags != NULL );
+
+    pConnectInfo = ( MQTTAgentConnectArgs_t * ) ( pConnectArgs );
+
+    ret = MQTT_Connect( &( pMqttAgentContext->mqttContext ),
+                        pConnectInfo->pConnectInfo,
+                        pConnectInfo->pWillInfo,
+                        pConnectInfo->timeoutMs,
+                        &( pConnectInfo->sessionPresent ) );
+
+    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+
+    return ret;
+}
+
+/*-----------------------------------------------------------*/
+
+MQTTStatus_t MQTTAgentCommand_Disconnect( MQTTAgentContext_t * pMqttAgentContext,
+                                          void * pUnusedArg,
+                                          MQTTAgentCommandFuncReturns_t * pReturnFlags )
+{
+    MQTTStatus_t ret;
+
+    ( void ) pUnusedArg;
+
+    assert( pMqttAgentContext != NULL );
+    assert( pReturnFlags != NULL );
+
+    ret = MQTT_Disconnect( &( pMqttAgentContext->mqttContext ) );
+
+    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+    pReturnFlags->endLoop = true;
+
+    return ret;
+}
+
+/*-----------------------------------------------------------*/
+
+MQTTStatus_t MQTTAgentCommand_Ping( MQTTAgentContext_t * pMqttAgentContext,
+                                    void * pUnusedArg,
+                                    MQTTAgentCommandFuncReturns_t * pReturnFlags )
+{
+    MQTTStatus_t ret;
+
+    ( void ) pUnusedArg;
+
+    assert( pMqttAgentContext != NULL );
+    assert( pReturnFlags != NULL );
+
+    ret = MQTT_Ping( &( pMqttAgentContext->mqttContext ) );
+
+    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+
+    if( ret == MQTTSuccess )
+    {
+        ret = runProcessLoops( pMqttAgentContext );
+    }
+
+    return ret;
+}
+
+/*-----------------------------------------------------------*/
+
+MQTTStatus_t MQTTAgentCommand_Terminate( MQTTAgentContext_t * pMqttAgentContext,
+                                         void * pUnusedArg,
+                                         MQTTAgentCommandFuncReturns_t * pReturnFlags )
+{
+    Command_t * pReceivedCommand = NULL;
+    bool receivedCommand = false;
+    MQTTAgentReturnInfo_t returnInfo = { 0 };
+
+    ( void ) pUnusedArg;
+
+    assert( pMqttAgentContext != NULL );
+    assert( pReturnFlags != NULL );
+
+    returnInfo.returnCode = MQTTBadResponse;
+
+    LogInfo( ( "Terminating command loop.\n" ) );
+    memset( pReturnFlags, 0x00, sizeof( MQTTAgentCommandFuncReturns_t ) );
+    pReturnFlags->endLoop = true;
+
+    /* Cancel all operations waiting in the queue. */
+    do
+    {
+        receivedCommand = Agent_MessageReceive( pMqttAgentContext->pMessageCtx,
+                                                &( pReceivedCommand ),
+                                                0U );
+
+        if( ( pReceivedCommand != NULL ) &&
+            ( pReceivedCommand->pCommandCompleteCallback != NULL ) )
+        {
+            pReceivedCommand->pCommandCompleteCallback( pReceivedCommand->pCmdContext, &returnInfo );
+        }
+    } while( receivedCommand );
+
+    return MQTTSuccess;
+}

--- a/lib/FreeRTOS/mqtt-agent/mqtt_agent_command_functions.h
+++ b/lib/FreeRTOS/mqtt-agent/mqtt_agent_command_functions.h
@@ -34,6 +34,10 @@
 /* MQTT Agent include. */
 #include "mqtt_agent.h"
 
+/**
+ * @brief An array of function pointers mapping commands to a function to
+ * execute.
+ */
 #ifndef MQTT_AGENT_FUNCTION_TABLE
     #define MQTT_AGENT_FUNCTION_TABLE                   \
     {                                                   \
@@ -49,21 +53,29 @@
     }
 #endif /* ifndef MQTT_AGENT_FUNCTION_TABLE */
 
-#define MQTT_AGENT_FLAG_COMMAND_COMPLETE    ( ( uint8_t ) 1U << 0 )
-#define MQTT_AGENT_ADD_ACKNOWLEDGMENT       ( ( uint8_t ) 1U << 1 )
-#define MQTT_AGENT_FLAG_END_LOOP            ( ( uint8_t ) 1U << 2 )
-
-
 /*-----------------------------------------------------------*/
 
+/**
+ * @brief A structure of values and flags expected to be returned
+ * by command functions.
+ */
 typedef struct MQTTAgentCommandFuncReturns
 {
-    uint16_t packetId;
-    bool endLoop;
-    bool addAcknowledgment;
-    bool runProcessLoop;
+    uint16_t packetId;      /**< @brief Packet ID of packet sent by command. */
+    bool endLoop;           /**< @brief Flag to indicate command loop should terminate. */
+    bool addAcknowledgment; /**< @brief Flag to indicate an acknowledgment should be tracked. */
+    bool runProcessLoop;    /**< @brief Flag to indicate MQTT_ProcessLoop() should be called after this command. */
 } MQTTAgentCommandFuncReturns_t;
 
+/**
+ * @brief Function prototype for a command.
+ *
+ * @param[in] pMqttAgentContext MQTT Agent context.
+ * @param[in] pArgs Arguments for the command.
+ * @param[out] pFlags Return flags set by the function.
+ *
+ * @return Return code of MQTT call.
+ */
 typedef MQTTStatus_t (* MQTTAgentCommandFunc_t ) ( MQTTAgentContext_t * pMqttAgentContext,
                                                    void * pArgs,
                                                    MQTTAgentCommandFuncReturns_t * pFlags );

--- a/lib/FreeRTOS/mqtt-agent/mqtt_agent_command_functions.h
+++ b/lib/FreeRTOS/mqtt-agent/mqtt_agent_command_functions.h
@@ -56,17 +56,17 @@
 
 /*-----------------------------------------------------------*/
 
-typedef MQTTStatus_t (* MQTTAgentCommandFunc_t ) ( MQTTAgentContext_t * pMqttAgentContext,
-                                                   void * pArgs,
-                                                   uint8_t * pFlags );
-
 typedef struct MQTTAgentCommandFuncReturns
 {
     uint16_t packetId;
     bool endLoop;
     bool addAcknowledgment;
-    bool completeCommand;
+    bool runProcessLoop;
 } MQTTAgentCommandFuncReturns_t;
+
+typedef MQTTStatus_t (* MQTTAgentCommandFunc_t ) ( MQTTAgentContext_t * pMqttAgentContext,
+                                                   void * pArgs,
+                                                   MQTTAgentCommandFuncReturns_t * pFlags );
 
 /*-----------------------------------------------------------*/
 
@@ -106,7 +106,7 @@ MQTTStatus_t MQTTAgentCommand_Publish( MQTTAgentContext_t * pMqttAgentContext,
  * @return Status code of MQTT_Subscribe().
  */
 MQTTStatus_t MQTTAgentCommand_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
-                                         void * pSubscribeArgs,
+                                         void * pVoidSubscribeArgs,
                                          MQTTAgentCommandFuncReturns_t * pReturnFlags );
 
 /**
@@ -119,7 +119,7 @@ MQTTStatus_t MQTTAgentCommand_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
  * @return Status code of MQTT_Unsubscribe().
  */
 MQTTStatus_t MQTTAgentCommand_Unsubscribe( MQTTAgentContext_t * pMqttAgentContext,
-                                           void * pSubscribeArgs,
+                                           void * pVoidSubscribeArgs,
                                            MQTTAgentCommandFuncReturns_t * pReturnFlags );
 
 /**

--- a/lib/FreeRTOS/mqtt-agent/mqtt_agent_command_functions.h
+++ b/lib/FreeRTOS/mqtt-agent/mqtt_agent_command_functions.h
@@ -1,0 +1,177 @@
+/*
+ * FreeRTOS V202011.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/**
+ * @file mqtt_agent_command_functions.h
+ * @brief Functions for processing an MQTT agent command.
+ */
+#ifndef MQTT_AGENT_COMMAND_FUNCTIONS_H
+#define MQTT_AGENT_COMMAND_FUNCTIONS_H
+
+/* MQTT Agent include. */
+#include "mqtt_agent.h"
+
+#ifndef MQTT_AGENT_FUNCTION_TABLE
+    #define MQTT_AGENT_FUNCTION_TABLE                   \
+    {                                                   \
+        [ NONE ] = MQTTAgentCommand_ProcessLoop,        \
+        [ PROCESSLOOP ] = MQTTAgentCommand_ProcessLoop, \
+        [ PUBLISH ] = MQTTAgentCommand_Publish,         \
+        [ SUBSCRIBE ] = MQTTAgentCommand_Subscribe,     \
+        [ UNSUBSCRIBE ] = MQTTAgentCommand_Unsubscribe, \
+        [ PING ] = MQTTAgentCommand_Ping,               \
+        [ CONNECT ] = MQTTAgentCommand_Connect,         \
+        [ DISCONNECT ] = MQTTAgentCommand_Disconnect,   \
+        [ TERMINATE ] = MQTTAgentCommand_Terminate      \
+    }
+#endif /* ifndef MQTT_AGENT_FUNCTION_TABLE */
+
+#define MQTT_AGENT_FLAG_COMMAND_COMPLETE    ( ( uint8_t ) 1U << 0 )
+#define MQTT_AGENT_ADD_ACKNOWLEDGMENT       ( ( uint8_t ) 1U << 1 )
+#define MQTT_AGENT_FLAG_END_LOOP            ( ( uint8_t ) 1U << 2 )
+
+
+/*-----------------------------------------------------------*/
+
+typedef MQTTStatus_t (* MQTTAgentCommandFunc_t ) ( MQTTAgentContext_t * pMqttAgentContext,
+                                                   void * pArgs,
+                                                   uint8_t * pFlags );
+
+typedef struct MQTTAgentCommandFuncReturns
+{
+    uint16_t packetId;
+    bool endLoop;
+    bool addAcknowledgment;
+    bool completeCommand;
+} MQTTAgentCommandFuncReturns_t;
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Function to execute for a NONE command.
+ *
+ * @param[in] pMqttAgentContext MQTT Agent context information.
+ * @param[in] pUnusedArg Unused NULL argument.
+ * @param[out] pReturnFlags Flags set to indicate actions the MQTT agent should take.
+ *
+ * @return Status code of MQTT_ProcessLoop().
+ */
+MQTTStatus_t MQTTAgentCommand_ProcessLoop( MQTTAgentContext_t * pMqttAgentContext,
+                                           void * pUnusedArg,
+                                           MQTTAgentCommandFuncReturns_t * pReturnFlags );
+
+/**
+ * @brief Function to execute for a PUBLISH command.
+ *
+ * @param[in] pMqttAgentContext MQTT Agent context information.
+ * @param[in] pPublishArg Publish information for MQTT_Publish().
+ * @param[out] pReturnFlags Flags set to indicate actions the MQTT agent should take.
+ *
+ * @return Status code of MQTT_Publish().
+ */
+MQTTStatus_t MQTTAgentCommand_Publish( MQTTAgentContext_t * pMqttAgentContext,
+                                       void * pPublishArg,
+                                       MQTTAgentCommandFuncReturns_t * pReturnFlags );
+
+/**
+ * @brief Function to execute for a SUBSCRIBE command.
+ *
+ * @param[in] pMqttAgentContext MQTT Agent context information.
+ * @param[in] pSubscribeArgs Arguments for MQTT_Subscribe().
+ * @param[out] pReturnFlags Flags set to indicate actions the MQTT agent should take.
+ *
+ * @return Status code of MQTT_Subscribe().
+ */
+MQTTStatus_t MQTTAgentCommand_Subscribe( MQTTAgentContext_t * pMqttAgentContext,
+                                         void * pSubscribeArgs,
+                                         MQTTAgentCommandFuncReturns_t * pReturnFlags );
+
+/**
+ * @brief Function to execute for an UNSUBSCRIBE command.
+ *
+ * @param[in] pMqttAgentContext MQTT Agent context information.
+ * @param[in] pSubscribeArgs Arguments for MQTT_Unsubscribe().
+ * @param[out] pReturnFlags Flags set to indicate actions the MQTT agent should take.
+ *
+ * @return Status code of MQTT_Unsubscribe().
+ */
+MQTTStatus_t MQTTAgentCommand_Unsubscribe( MQTTAgentContext_t * pMqttAgentContext,
+                                           void * pSubscribeArgs,
+                                           MQTTAgentCommandFuncReturns_t * pReturnFlags );
+
+/**
+ * @brief Function to execute for a CONNECT command.
+ *
+ * @param[in] pMqttAgentContext MQTT Agent context information.
+ * @param[in] pConnectArgs Arguments for MQTT_Connect().
+ * @param[out] pReturnFlags Flags set to indicate actions the MQTT agent should take.
+ *
+ * @return Status code of MQTT_Connect().
+ */
+MQTTStatus_t MQTTAgentCommand_Connect( MQTTAgentContext_t * pMqttAgentContext,
+                                       void * pConnectArgs,
+                                       MQTTAgentCommandFuncReturns_t * pReturnFlags );
+
+/**
+ * @brief Function to execute for a DISCONNECT command.
+ *
+ * @param[in] pMqttAgentContext MQTT Agent context information.
+ * @param[in] pUnusedArg Unused NULL argument.
+ * @param[out] pReturnFlags Flags set to indicate actions the MQTT agent should take.
+ *
+ * @return Status code of MQTT_Disconnect().
+ */
+MQTTStatus_t MQTTAgentCommand_Disconnect( MQTTAgentContext_t * pMqttAgentContext,
+                                          void * pUnusedArg,
+                                          MQTTAgentCommandFuncReturns_t * pReturnFlags );
+
+/**
+ * @brief Function to execute for a PING command.
+ *
+ * @param[in] pMqttAgentContext MQTT Agent context information.
+ * @param[in] pUnusedArg Unused NULL argument.
+ * @param[out] pReturnFlags Flags set to indicate actions the MQTT agent should take.
+ *
+ * @return Status code of MQTT_Ping().
+ */
+MQTTStatus_t MQTTAgentCommand_Ping( MQTTAgentContext_t * pMqttAgentContext,
+                                    void * pUnusedArg,
+                                    MQTTAgentCommandFuncReturns_t * pReturnFlags );
+
+/**
+ * @brief Function to execute for a TERMINATE command.
+ *
+ * @param[in] pMqttAgentContext MQTT Agent context information.
+ * @param[in] pUnusedArg Unused NULL argument.
+ * @param[out] pReturnFlags Flags set to indicate actions the MQTT agent should take.
+ *
+ * @return `MQTTSuccess`.
+ */
+MQTTStatus_t MQTTAgentCommand_Terminate( MQTTAgentContext_t * pMqttAgentContext,
+                                         void * pUnusedArg,
+                                         MQTTAgentCommandFuncReturns_t * pReturnFlags );
+
+#endif /* MQTT_AGENT_COMMAND_FUNCTIONS_H */


### PR DESCRIPTION
*Description*:
Adds a new file `mqtt_agent_command_functions.c` to replaces the switch statement used to determine the action for each command with a function pointer array. In order to exclude unneeded functions, this array can be overridden by defining a macro in `core_mqtt_config.h`:
```
#define MQTT_AGENT_FUNCTION_TABLE                   \
{                                                   \
    [ NONE ] = MQTTAgentCommand_ProcessLoop,        \
    [ PROCESSLOOP ] = MQTTAgentCommand_ProcessLoop, \
    [ PUBLISH ] = MQTTAgentCommand_Publish,         \
    [ SUBSCRIBE ] = MQTTAgentCommand_Subscribe,     \
    [ UNSUBSCRIBE ] = MQTTAgentCommand_Unsubscribe, \
    [ PING ] = MQTTAgentCommand_Ping,               \
    [ CONNECT ] = MQTTAgentCommand_Connect,         \
    [ DISCONNECT ] = MQTTAgentCommand_Disconnect,   \
    [ TERMINATE ] = MQTTAgentCommand_Terminate      \
}
```
The macro uses designated initializers present in C99 and as a GNU C extension for C90. If neither C99 nor GCC is used, then the macro can still be defined without the enums, it just will not look as pretty.

Note that `MQTT_ProcessLoop` is still called from `mqtt_agent.c`. This could be moved to `mqtt_agent_command_functions.c` along with the other coreMQTT calls, however then acknowledgments would need to be added to the list from there as well. `MQTT_ProcessLoop` was kept where it was so that elements would be added to and removed from the acknowledgments list from the same file rather than splitting up the addition/removal across files.