### PR TITLE
Fix include for netstat utility

### DIFF
--- a/source/configuration-files/FreeRTOSIPConfig.h
+++ b/source/configuration-files/FreeRTOSIPConfig.h
@@ -308,4 +308,7 @@ extern UBaseType_t uxRand();
 
 #define portINLINE                          __inline
 
+/* Include the tcp_netstat utility. */
+#include "tcp_netstat.h"
+
 #endif /* FREERTOS_IP_CONFIG_H */

--- a/source/defender-tools/metrics_collector.c
+++ b/source/defender-tools/metrics_collector.c
@@ -43,9 +43,6 @@
 #include "FreeRTOS.h"
 #include "FreeRTOS_IP.h"
 
-/* FreeRTOS+TCP tcp_netstat utility include. */
-#include "tcp_netstat.h"
-
 /* Demo config. */
 #include "demo_config.h"
 


### PR DESCRIPTION
The tcp_netstat header should be included in FreeRTOSIPConfig.h, as it defines macros used by FreeRTOS+TCP in order to count total bytes sent/received.