### PR TITLE
Add mqtt network buffer size check in OTA demo

### DIFF
--- a/source/ota_over_mqtt_demo.c
+++ b/source/ota_over_mqtt_demo.c
@@ -77,7 +77,7 @@
 #endif
 
 #if !defined( MQTT_AGENT_NETWORK_BUFFER_SIZE ) || ( MQTT_AGENT_NETWORK_BUFFER_SIZE < OTA_DATA_BLOCK_SIZE )
-    #error "Please define MQTT_AGENT_NETWORK_BUFFER_SIZE to adequate size as required by OTA data block"
+#error "MQTT agent buffer is too small. Please increase the buffer size to atleast the size required for OTA data block."
 #endif
 
 /**

--- a/source/ota_over_mqtt_demo.c
+++ b/source/ota_over_mqtt_demo.c
@@ -51,14 +51,10 @@
 #include "task.h"
 #include "semphr.h"
 
-#include "ota_config.h"
 #include "demo_config.h"
 
 /* MQTT library includes. */
 #include "mqtt_agent.h"
-
-/* Subscription manager header include. */
-#include "subscription_manager.h"
 
 /* OTA Library include. */
 #include "ota.h"
@@ -78,6 +74,10 @@
 
 #ifndef democonfigCLIENT_IDENTIFIER
     #error "Please define the democonfigCLIENT_IDENTIFIER with the thing name for which OTA is performed"
+#endif
+
+#if !defined( MQTT_AGENT_NETWORK_BUFFER_SIZE ) || ( MQTT_AGENT_NETWORK_BUFFER_SIZE < OTA_DATA_BLOCK_SIZE )
+    #error "Please define MQTT_AGENT_NETWORK_BUFFER_SIZE to adequate size as required by OTA data block"
 #endif
 
 /**


### PR DESCRIPTION
Added a compile time check to verify mqtt network buffer size is enough to store largest OTA block.
Removed unused includes.