### PR TITLE
Update Agent submodule

### DIFF
--- a/build/VisualStudio/WIN32.vcxproj
+++ b/build/VisualStudio/WIN32.vcxproj
@@ -26,8 +26,8 @@
     <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\core_mqtt_state.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\mqtt_agent.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\mqtt_agent_command_functions.c" />
-    <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\portable\freertos\agent_command_pool.c" />
-    <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\portable\freertos\agent_message.c" />
+    <ClCompile Include="..\..\lib\FreeRTOS\mqtt-agent-interface\freertos_command_pool.c" />
+    <ClCompile Include="..\..\lib\FreeRTOS\mqtt-agent-interface\freertos_agent_message.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-kernel\event_groups.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-kernel\list.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\freertos-kernel\portable\MemMang\heap_4.c" />
@@ -85,10 +85,11 @@
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\include\core_mqtt_serializer.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\include\core_mqtt_state.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface\transport_interface.h" />
-    <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\include\agent_command_pool.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\include\agent_message.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\include\mqtt_agent.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\include\mqtt_agent_command_functions.h" />
+    <ClInclude Include="..\..\lib\FreeRTOS\mqtt-agent-interface\freertos_command_pool.h" />
+    <ClInclude Include="..\..\lib\FreeRTOS\mqtt-agent-interface\freertos_agent_message.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-kernel\include\event_groups.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-kernel\include\FreeRTOS.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-kernel\include\message_buffer.h" />
@@ -197,7 +198,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\lib\AWS;..\..\lib\FreeRTOS\utilities\crypto\include;..\..\lib\AWS\ota-pal\Win32;..\..\lib\ThirdParty\tinycbor\src;..\..\lib\FreeRTOS\coreJSON\source\include;..\..\lib\AWS\ota\source\portable\os;..\..\lib\AWS\ota\source\include;..\..\lib\AWS\defender\source\include;..\..\lib\FreeRTOS\utilities\mbedtls_freertos;..\..\lib\FreeRTOS\utilities\backoffAlgorithm\source\include;..\..\lib\ThirdParty\mbedtls\include;..\..\lib\FreeRTOS\coreMQTT-Agent\source\include;..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface;..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\include;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp;..\..\lib\FreeRTOS\utilities\logging;..\..\lib\FreeRTOS\freertos-plus-tcp\include;..\..\lib\FreeRTOS\freertos-plus-tcp\tools\tcp_utilities\include;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp\using_mbedtls;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp\using_plaintext;..\..\lib\FreeRTOS\freertos-plus-tcp\portable\Compiler\MSVC;..\..\source\subscription-manager;..\..\source\configuration-files;..\..\source\defender-tools;..\..\lib\FreeRTOS\freertos-kernel\portable\MSVC-MingW;..\..\lib\FreeRTOS\freertos-kernel\include;..\..\lib\ThirdParty\WinPCap;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\lib\AWS;..\..\lib\FreeRTOS\utilities\crypto\include;..\..\lib\AWS\ota-pal\Win32;..\..\lib\ThirdParty\tinycbor\src;..\..\lib\FreeRTOS\coreJSON\source\include;..\..\lib\AWS\ota\source\portable\os;..\..\lib\AWS\ota\source\include;..\..\lib\AWS\defender\source\include;..\..\lib\FreeRTOS\utilities\mbedtls_freertos;..\..\lib\FreeRTOS\utilities\backoffAlgorithm\source\include;..\..\lib\ThirdParty\mbedtls\include;..\..\lib\FreeRTOS\coreMQTT-Agent\source\include;..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface;..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\include;..\..\lib\FreeRTOS\mqtt-agent-interface;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp;..\..\lib\FreeRTOS\utilities\logging;..\..\lib\FreeRTOS\freertos-plus-tcp\include;..\..\lib\FreeRTOS\freertos-plus-tcp\tools\tcp_utilities\include;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp\using_mbedtls;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp\using_plaintext;..\..\lib\FreeRTOS\freertos-plus-tcp\portable\Compiler\MSVC;..\..\source\subscription-manager;..\..\source\configuration-files;..\..\source\defender-tools;..\..\lib\FreeRTOS\freertos-kernel\portable\MSVC-MingW;..\..\lib\FreeRTOS\freertos-kernel\include;..\..\lib\ThirdParty\WinPCap;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MBEDTLS_CONFIG_FILE="mbedtls_config.h";WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>

--- a/build/VisualStudio/WIN32.vcxproj.filters
+++ b/build/VisualStudio/WIN32.vcxproj.filters
@@ -148,12 +148,6 @@
     <Filter Include="Lib\FreeRTOS\coreMQTT-Agent\source\dependency">
       <UniqueIdentifier>{e0622250-531a-472d-9cdb-a63a973893eb}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Lib\FreeRTOS\coreMQTT-Agent\source\portable">
-      <UniqueIdentifier>{3396fcb7-3734-42ca-a0d5-740a614321ac}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Lib\FreeRTOS\coreMQTT-Agent\source\portable\freertos">
-      <UniqueIdentifier>{97ac1145-b309-46a9-a41b-883d1793e926}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT">
       <UniqueIdentifier>{d482244b-1fb3-4ac8-b8de-88e894b360d7}</UniqueIdentifier>
     </Filter>
@@ -165,6 +159,9 @@
     </Filter>
     <Filter Include="Lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface">
       <UniqueIdentifier>{d852f1f2-242b-4f62-a469-bc8f51e6d5a4}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Lib\FreeRTOS\MQTT-Agent-Interface">
+      <UniqueIdentifier>{fefad340-836c-4887-afa9-8a31e570221e}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -339,12 +336,6 @@
     <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\mqtt_agent_command_functions.c">
       <Filter>Lib\FreeRTOS\coreMQTT-Agent\source</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\portable\freertos\agent_command_pool.c">
-      <Filter>Lib\FreeRTOS\coreMQTT-Agent\source\portable\freertos</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\portable\freertos\agent_message.c">
-      <Filter>Lib\FreeRTOS\coreMQTT-Agent\source\portable\freertos</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\core_mqtt.c">
       <Filter>Lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source</Filter>
     </ClCompile>
@@ -353,6 +344,12 @@
     </ClCompile>
     <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\core_mqtt_state.c">
       <Filter>Lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\FreeRTOS\mqtt-agent-interface\freertos_agent_message.c">
+      <Filter>Lib\FreeRTOS\MQTT-Agent-Interface</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\lib\FreeRTOS\mqtt-agent-interface\freertos_command_pool.c">
+      <Filter>Lib\FreeRTOS\MQTT-Agent-Interface</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -524,9 +521,6 @@
     <ClInclude Include="..\..\lib\FreeRTOS\freertos-plus-tcp\tools\tcp_utilities\include\tcp_netstat.h">
       <Filter>Lib\FreeRTOS\FreeRTOS-Plus-TCP\tcp_utilities\include</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\include\agent_command_pool.h">
-      <Filter>Lib\FreeRTOS\coreMQTT-Agent\source\include</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\include\agent_message.h">
       <Filter>Lib\FreeRTOS\coreMQTT-Agent\source\include</Filter>
     </ClInclude>
@@ -550,6 +544,12 @@
     </ClInclude>
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface\transport_interface.h">
       <Filter>Lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\FreeRTOS\mqtt-agent-interface\freertos_agent_message.h">
+      <Filter>Lib\FreeRTOS\MQTT-Agent-Interface</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\FreeRTOS\mqtt-agent-interface\freertos_command_pool.h">
+      <Filter>Lib\FreeRTOS\MQTT-Agent-Interface</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.c
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.c
@@ -1,0 +1,73 @@
+/*
+ * FreeRTOS V202011.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/**
+ * @file freertos_agent_message.c
+ * @brief Implements functions to interact with queues.
+ */
+
+/* Standard includes. */
+#include <string.h>
+#include <stdio.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "semphr.h"
+
+/* Header include. */
+#include "freertos_agent_message.h"
+
+/*-----------------------------------------------------------*/
+
+bool Agent_MessageSend( const AgentMessageContext_t * pMsgCtx,
+                        const void * pData,
+                        uint32_t blockTimeMs )
+{
+    BaseType_t queueStatus = pdFAIL;
+
+    if( ( pMsgCtx != NULL ) && ( pData != NULL ) )
+    {
+        queueStatus = xQueueSendToBack( pMsgCtx->queue, pData, pdMS_TO_TICKS( blockTimeMs ) );
+    }
+
+    return ( queueStatus == pdPASS ) ? true : false;
+}
+
+/*-----------------------------------------------------------*/
+
+bool Agent_MessageReceive( const AgentMessageContext_t * pMsgCtx,
+                           void * pBuffer,
+                           uint32_t blockTimeMs )
+{
+    BaseType_t queueStatus = pdFAIL;
+
+    if( ( pMsgCtx != NULL ) && ( pBuffer != NULL ) )
+    {
+        queueStatus = xQueueReceive( pMsgCtx->queue, pBuffer, pdMS_TO_TICKS( blockTimeMs ) );
+    }
+
+    return ( queueStatus == pdPASS ) ? true : false;
+}

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.c
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.c
@@ -39,6 +39,7 @@
 
 /* Header include. */
 #include "freertos_agent_message.h"
+#include "agent_message.h"
 
 /*-----------------------------------------------------------*/
 

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.h
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.h
@@ -1,0 +1,80 @@
+/*
+ * FreeRTOS V202011.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/**
+ * @file agent_message.h
+ * @brief Functions to interact with queues.
+ */
+#ifndef AGENT_MESSAGE_H
+#define AGENT_MESSAGE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+/* Include MQTT agent messaging interface. */
+#include "agent_message.h"
+
+/**
+ * @ingroup mqtt_agent_struct_types
+ * @brief Context with which tasks may deliver messages to the agent.
+ */
+struct AgentMessageContext
+{
+    QueueHandle_t queue;
+};
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Send a message to the specified context.
+ * Must be thread safe.
+ *
+ * @param[in] pMsgCtx An #AgentMessageContext_t.
+ * @param[in] pData Pointer to element to send to queue.
+ * @param[in] blockTimeMs Block time to wait for a send.
+ *
+ * @return `true` if send was successful, else `false`.
+ */
+bool Agent_MessageSend( const AgentMessageContext_t * pMsgCtx,
+                        const void * pData,
+                        uint32_t blockTimeMs );
+
+/**
+ * @brief Receive a message from the specified context.
+ * Must be thread safe.
+ *
+ * @param[in] pMsgCtx An #AgentMessageContext_t.
+ * @param[in] pBuffer Pointer to buffer to write received data.
+ * @param[in] blockTimeMs Block time to wait for a receive.
+ *
+ * @return `true` if receive was successful, else `false`.
+ */
+bool Agent_MessageReceive( const AgentMessageContext_t * pMsgCtx,
+                           void * pBuffer,
+                           uint32_t blockTimeMs );
+
+#endif /* AGENT_MESSAGE_H */

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.h
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.h
@@ -28,8 +28,8 @@
  * @file agent_message.h
  * @brief Functions to interact with queues.
  */
-#ifndef AGENT_MESSAGE_H
-#define AGENT_MESSAGE_H
+#ifndef FREERTOS_AGENT_MESSAGE_H
+#define FREERTOS_AGENT_MESSAGE_H
 
 #include <stddef.h>
 #include <stdint.h>
@@ -81,4 +81,4 @@ bool Agent_MessageReceive( const AgentMessageContext_t * pMsgCtx,
                            void * pBuffer,
                            uint32_t blockTimeMs );
 
-#endif /* AGENT_MESSAGE_H */
+#endif /* FREERTOS_AGENT_MESSAGE_H */

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.h
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.h
@@ -25,7 +25,7 @@
  */
 
 /**
- * @file agent_message.h
+ * @file freertos_agent_message.h
  * @brief Functions to interact with queues.
  */
 #ifndef FREERTOS_AGENT_MESSAGE_H

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.h
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_agent_message.h
@@ -35,6 +35,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+/* FreeRTOS includes. */
+#include "FreeRTOS.h"
+#include "queue.h"
+
 /* Include MQTT agent messaging interface. */
 #include "agent_message.h"
 

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.c
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.c
@@ -39,12 +39,13 @@
 
 /* Header include. */
 #include "freertos_command_pool.h"
+#include "freertos_agent_message.h"
 
 /*-----------------------------------------------------------*/
 
-#define SEMAPHORES_NOT_INITIALIZED    ( 0U )
-#define SEMAPHORES_INIT_PENDING       ( 1U )
-#define SEMAPHORES_INITIALIZED        ( 2U )
+#define QUEUE_NOT_INITIALIZED    ( 0U )
+#define QUEUE_INIT_PENDING       ( 1U )
+#define QUEUE_INITIALIZED        ( 2U )
 
 /**
  * @brief The pool of command structures used to hold information on commands (such
@@ -54,87 +55,48 @@
 static Command_t commandStructurePool[ MQTT_COMMAND_CONTEXTS_POOL_SIZE ];
 
 /**
- * @brief An array of semaphores to guard each Command_t structure in the pool.
- * Structures must be obtained by first obtaining its associated semaphore.
+ * @brief A queue used to guard the pool of Command_t structures. Structures
+ * may be obtained by receiving a pointer from the queue, and returned by
+ * sending the pointer back into it.
  */
-static SemaphoreHandle_t commandSems[ MQTT_COMMAND_CONTEXTS_POOL_SIZE ];
+static AgentMessageContext_t commandStructQueue;
 
 /**
- * @brief Initialization status of the command semaphore array.
+ * @brief Initialization status of the queue.
  */
-static volatile uint8_t initStatus = SEMAPHORES_NOT_INITIALIZED;
+static volatile uint8_t initStatus = QUEUE_NOT_INITIALIZED;
 
 /*-----------------------------------------------------------*/
 
-/**
- * @brief Initialize the pool of command structures.
- */
-static void initializePool( void );
-
-/**
- * @brief Iterate through the array of command structures until one is
- * available or the end is reached.
- *
- * @return Pointer to available command structure, or NULL.
- */
-static Command_t * getCommand( void );
-
-/*-----------------------------------------------------------*/
-
-static void initializePool( void )
+void Agent_InitializePool( void )
 {
-    bool owner = false;
     size_t i;
-    static StaticSemaphore_t commandSemsStorage[ MQTT_COMMAND_CONTEXTS_POOL_SIZE ];
-    BaseType_t semaphoreCreated = pdFALSE;
+    Command_t * pCommand;
+    static uint8_t staticQueueStorageArea[ MQTT_COMMAND_CONTEXTS_POOL_SIZE * sizeof( Command_t * ) ];
+    static StaticQueue_t staticQueueStructure;
+    bool commandAdded = false;
 
-    taskENTER_CRITICAL();
-    {
-        if( initStatus == SEMAPHORES_NOT_INITIALIZED )
-        {
-            owner = true;
-            initStatus = SEMAPHORES_INIT_PENDING;
-        }
-    }
-    taskEXIT_CRITICAL();
-
-    if( owner )
+    if( initStatus == QUEUE_NOT_INITIALIZED )
     {
         memset( ( void * ) commandStructurePool, 0x00, sizeof( commandStructurePool ) );
+        commandStructQueue.queue = xQueueCreateStatic( MQTT_COMMAND_CONTEXTS_POOL_SIZE,
+                                                       sizeof( Command_t * ),
+                                                       staticQueueStorageArea,
+                                                       &staticQueueStructure );
+        configASSERT( commandStructQueue.queue );
 
-        /* Create a binary semaphore for each command. */
+        /* Populate the queue. */
         for( i = 0; i < MQTT_COMMAND_CONTEXTS_POOL_SIZE; i++ )
         {
-            commandSems[ i ] = xSemaphoreCreateBinaryStatic( &commandSemsStorage[ i ] );
-            semaphoreCreated = xSemaphoreGive( commandSems[ i ] );
-            configASSERT( semaphoreCreated == pdTRUE );
+            /* Store the address as a variable. */
+            pCommand = &commandStructurePool[ i ];
+            /* Send the pointer to the queue. */
+            commandAdded = Agent_MessageSend( &commandStructQueue, &pCommand, 0U );
+            configASSERT( commandAdded );
         }
 
-        initStatus = SEMAPHORES_INITIALIZED;
+        initStatus = QUEUE_INITIALIZED;
     }
-}
-
-/*-----------------------------------------------------------*/
-
-static Command_t * getCommand( void )
-{
-    Command_t * structToUse = NULL;
-    size_t i;
-
-    for( i = 0; i < MQTT_COMMAND_CONTEXTS_POOL_SIZE; i++ )
-    {
-        if( xSemaphoreTake( commandSems[ i ], 0 ) == pdTRUE )
-        {
-            break;
-        }
-    }
-
-    if( i < MQTT_COMMAND_CONTEXTS_POOL_SIZE )
-    {
-        structToUse = &( commandStructurePool[ i ] );
-    }
-
-    return structToUse;
 }
 
 /*-----------------------------------------------------------*/
@@ -142,32 +104,19 @@ static Command_t * getCommand( void )
 Command_t * Agent_GetCommand( uint32_t blockTimeMs )
 {
     Command_t * structToUse = NULL;
-    uint32_t cumulativeDelayMs = 0U;
+    size_t i;
+    bool structRetrieved = false;
 
-    /* Check here so we do not enter a critical section every time. */
-    if( initStatus == SEMAPHORES_NOT_INITIALIZED )
+    /* Check queue has been created. */
+    if( initStatus == QUEUE_INITIALIZED )
     {
-        initializePool();
-    }
+        /* Retrieve a struct from the queue. */
+        structRetrieved = Agent_MessageReceive( &commandStructQueue, &( structToUse ), blockTimeMs );
 
-    /* Check semaphores have been created. */
-    if( initStatus == SEMAPHORES_INITIALIZED )
-    {
-        do
+        if( !structRetrieved )
         {
-            structToUse = getCommand();
-
-            if( structToUse == NULL )
-            {
-                vTaskDelay( pdMS_TO_TICKS( 1 ) );
-                cumulativeDelayMs++;
-            }
-        } while( ( structToUse == NULL ) && ( cumulativeDelayMs < blockTimeMs ) );
-    }
-
-    if( structToUse == NULL )
-    {
-        LogError( ( "No command structure available." ) );
+            LogError( ( "No command structure available." ) );
+        }
     }
 
     return structToUse;
@@ -177,22 +126,17 @@ Command_t * Agent_GetCommand( uint32_t blockTimeMs )
 
 bool Agent_ReleaseCommand( Command_t * pCommandToRelease )
 {
-    size_t commandIndex;
+    size_t i;
     bool structReturned = false;
 
-    /* Calculate the index of the struct. */
-    commandIndex = pCommandToRelease - commandStructurePool;
-
-    /* Ensure the structure being returned is actually from the pool. */
-    if( commandIndex < MQTT_COMMAND_CONTEXTS_POOL_SIZE )
+    /* See if the structure being returned is actually from the pool. */
+    if( ( pCommandToRelease >= commandStructurePool ) &&
+        ( pCommandToRelease < ( commandStructurePool + MQTT_COMMAND_CONTEXTS_POOL_SIZE ) ) )
     {
-        structReturned = ( bool ) xSemaphoreGive( commandSems[ commandIndex ] );
-    }
-
-    if( structReturned )
-    {
+        structReturned = Agent_MessageSend( &commandStructQueue, &pCommandToRelease, 0U );
+        configASSERT( structReturned );
         LogDebug( ( "Returned Command Context %d to pool",
-                    ( int ) commandIndex ) );
+                    ( int ) ( pCommandToRelease - commandStructurePool ) ) );
     }
 
     return structReturned;

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.c
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.c
@@ -54,8 +54,9 @@
 static Command_t commandStructurePool[ MQTT_COMMAND_CONTEXTS_POOL_SIZE ];
 
 /**
- * @brief A queue used to guard the pool of Command_t structures. Structures
- * may be obtained by receiving a pointer from the queue, and returned by
+ * @brief The message context used to guard the pool of Command_t structures.
+ * For FreeRTOS, this is implemented with a queue. Structures may be
+ * obtained by receiving a pointer from the queue, and returned by
  * sending the pointer back into it.
  */
 static AgentMessageContext_t commandStructMessageCtx;

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.c
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.c
@@ -107,15 +107,14 @@ Command_t * Agent_GetCommand( uint32_t blockTimeMs )
     bool structRetrieved = false;
 
     /* Check queue has been created. */
-    if( initStatus == QUEUE_INITIALIZED )
-    {
-        /* Retrieve a struct from the queue. */
-        structRetrieved = Agent_MessageReceive( &commandStructQueue, &( structToUse ), blockTimeMs );
+    configASSERT( initStatus == QUEUE_INITIALIZED );
 
-        if( !structRetrieved )
-        {
-            LogError( ( "No command structure available." ) );
-        }
+    /* Retrieve a struct from the queue. */
+    structRetrieved = Agent_MessageReceive( &commandStructQueue, &( structToUse ), blockTimeMs );
+
+    if( !structRetrieved )
+    {
+        LogError( ( "No command structure available." ) );
     }
 
     return structToUse;
@@ -128,11 +127,16 @@ bool Agent_ReleaseCommand( Command_t * pCommandToRelease )
     size_t i;
     bool structReturned = false;
 
+    configASSERT( initStatus == QUEUE_INITIALIZED );
+
     /* See if the structure being returned is actually from the pool. */
     if( ( pCommandToRelease >= commandStructurePool ) &&
         ( pCommandToRelease < ( commandStructurePool + MQTT_COMMAND_CONTEXTS_POOL_SIZE ) ) )
     {
         structReturned = Agent_MessageSend( &commandStructQueue, &pCommandToRelease, 0U );
+
+        /* The send should not fail as the queue was created to hold every command
+         * in the pool. */
         configASSERT( structReturned );
         LogDebug( ( "Returned Command Context %d to pool",
                     ( int ) ( pCommandToRelease - commandStructurePool ) ) );

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.c
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.c
@@ -1,0 +1,199 @@
+/*
+ * FreeRTOS V202011.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/**
+ * @file freertos_command_pool.c
+ * @brief Implements functions to obtain and release commands.
+ */
+
+/* Standard includes. */
+#include <string.h>
+#include <stdio.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "semphr.h"
+
+/* Header include. */
+#include "freertos_command_pool.h"
+
+/*-----------------------------------------------------------*/
+
+#define SEMAPHORES_NOT_INITIALIZED    ( 0U )
+#define SEMAPHORES_INIT_PENDING       ( 1U )
+#define SEMAPHORES_INITIALIZED        ( 2U )
+
+/**
+ * @brief The pool of command structures used to hold information on commands (such
+ * as PUBLISH or SUBSCRIBE) between the command being created by an API call and
+ * completion of the command by the execution of the command's callback.
+ */
+static Command_t commandStructurePool[ MQTT_COMMAND_CONTEXTS_POOL_SIZE ];
+
+/**
+ * @brief An array of semaphores to guard each Command_t structure in the pool.
+ * Structures must be obtained by first obtaining its associated semaphore.
+ */
+static SemaphoreHandle_t commandSems[ MQTT_COMMAND_CONTEXTS_POOL_SIZE ];
+
+/**
+ * @brief Initialization status of the command semaphore array.
+ */
+static volatile uint8_t initStatus = SEMAPHORES_NOT_INITIALIZED;
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Initialize the pool of command structures.
+ */
+static void initializePool( void );
+
+/**
+ * @brief Iterate through the array of command structures until one is
+ * available or the end is reached.
+ *
+ * @return Pointer to available command structure, or NULL.
+ */
+static Command_t * getCommand( void );
+
+/*-----------------------------------------------------------*/
+
+static void initializePool( void )
+{
+    bool owner = false;
+    size_t i;
+    static StaticSemaphore_t commandSemsStorage[ MQTT_COMMAND_CONTEXTS_POOL_SIZE ];
+    BaseType_t semaphoreCreated = pdFALSE;
+
+    taskENTER_CRITICAL();
+    {
+        if( initStatus == SEMAPHORES_NOT_INITIALIZED )
+        {
+            owner = true;
+            initStatus = SEMAPHORES_INIT_PENDING;
+        }
+    }
+    taskEXIT_CRITICAL();
+
+    if( owner )
+    {
+        memset( ( void * ) commandStructurePool, 0x00, sizeof( commandStructurePool ) );
+
+        /* Create a binary semaphore for each command. */
+        for( i = 0; i < MQTT_COMMAND_CONTEXTS_POOL_SIZE; i++ )
+        {
+            commandSems[ i ] = xSemaphoreCreateBinaryStatic( &commandSemsStorage[ i ] );
+            semaphoreCreated = xSemaphoreGive( commandSems[ i ] );
+            configASSERT( semaphoreCreated == pdTRUE );
+        }
+
+        initStatus = SEMAPHORES_INITIALIZED;
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static Command_t * getCommand( void )
+{
+    Command_t * structToUse = NULL;
+    size_t i;
+
+    for( i = 0; i < MQTT_COMMAND_CONTEXTS_POOL_SIZE; i++ )
+    {
+        if( xSemaphoreTake( commandSems[ i ], 0 ) == pdTRUE )
+        {
+            break;
+        }
+    }
+
+    if( i < MQTT_COMMAND_CONTEXTS_POOL_SIZE )
+    {
+        structToUse = &( commandStructurePool[ i ] );
+    }
+
+    return structToUse;
+}
+
+/*-----------------------------------------------------------*/
+
+Command_t * Agent_GetCommand( uint32_t blockTimeMs )
+{
+    Command_t * structToUse = NULL;
+    uint32_t cumulativeDelayMs = 0U;
+
+    /* Check here so we do not enter a critical section every time. */
+    if( initStatus == SEMAPHORES_NOT_INITIALIZED )
+    {
+        initializePool();
+    }
+
+    /* Check semaphores have been created. */
+    if( initStatus == SEMAPHORES_INITIALIZED )
+    {
+        do
+        {
+            structToUse = getCommand();
+
+            if( structToUse == NULL )
+            {
+                vTaskDelay( pdMS_TO_TICKS( 1 ) );
+                cumulativeDelayMs++;
+            }
+        } while( ( structToUse == NULL ) && ( cumulativeDelayMs < blockTimeMs ) );
+    }
+
+    if( structToUse == NULL )
+    {
+        LogError( ( "No command structure available." ) );
+    }
+
+    return structToUse;
+}
+
+/*-----------------------------------------------------------*/
+
+bool Agent_ReleaseCommand( Command_t * pCommandToRelease )
+{
+    size_t commandIndex;
+    bool structReturned = false;
+
+    /* Calculate the index of the struct. */
+    commandIndex = pCommandToRelease - commandStructurePool;
+
+    /* Ensure the structure being returned is actually from the pool. */
+    if( commandIndex < MQTT_COMMAND_CONTEXTS_POOL_SIZE )
+    {
+        structReturned = ( bool ) xSemaphoreGive( commandSems[ commandIndex ] );
+    }
+
+    if( structReturned )
+    {
+        LogDebug( ( "Returned Command Context %d to pool",
+                    ( int ) commandIndex ) );
+    }
+
+    return structReturned;
+}

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.c
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.c
@@ -44,8 +44,7 @@
 /*-----------------------------------------------------------*/
 
 #define QUEUE_NOT_INITIALIZED    ( 0U )
-#define QUEUE_INIT_PENDING       ( 1U )
-#define QUEUE_INITIALIZED        ( 2U )
+#define QUEUE_INITIALIZED        ( 1U )
 
 /**
  * @brief The pool of command structures used to hold information on commands (such

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.h
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.h
@@ -1,0 +1,78 @@
+/*
+ * FreeRTOS V202011.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://aws.amazon.com/freertos
+ *
+ */
+
+/**
+ * @file freertos_command_pool.h
+ * @brief Functions to obtain and release a command.
+ */
+#ifndef FREERTOS_COMMAND_POOL_H
+#define FREERTOS_COMMAND_POOL_H
+
+/* MQTT agent includes. */
+#include "mqtt_agent.h"
+
+/**
+ * @brief Obtain a Command_t structure from the pool of structures managed by the agent.
+ *
+ * @note Command_t structures hold everything the MQTT agent needs to process a
+ * command that originates from application.  Examples of commands are PUBLISH and
+ * SUBSCRIBE.  The Command_t structure must persist for the duration of the command's
+ * operation so are obtained from a pool of statically allocated structures when a
+ * new command is created, and returned to the pool when the command is complete.
+ * The MQTT_COMMAND_CONTEXTS_POOL_SIZE configuration file constant defines how many
+ * structures the pool contains.
+ *
+ * @param[in] blockTimeMs The length of time the calling task should remain in the
+ * Blocked state (so not consuming any CPU time) to wait for a Command_t structure to
+ * become available should one not be immediately at the time of the call.
+ *
+ * @return A pointer to a Command_t structure if one becomes available before
+ * blockTimeMs time expired, otherwise NULL.
+ */
+Command_t * Agent_GetCommand( uint32_t blockTimeMs );
+
+/**
+ * @brief Give a Command_t structure back to the the pool of structures managed by
+ * the agent.
+ *
+ * @note Command_t structures hold everything the MQTT agent needs to process a
+ * command that originates from application.  Examples of commands are PUBLISH and
+ * SUBSCRIBE.  The Command_t structure must persist for the duration of the command's
+ * operation so are obtained from a pool of statically allocated structures when a
+ * new command is created, and returned to the pool when the command is complete.
+ * The MQTT_COMMAND_CONTEXTS_POOL_SIZE configuration file constant defines how many
+ * structures the pool contains.
+ *
+ * @param[in] pCommandToRelease A pointer to the Command_t structure to return to
+ * the pool.  The structure must first have been obtained by calling
+ * Agent_GetCommand(), otherwise Agent_ReleaseCommand() will
+ * have no effect.
+ *
+ * @return true if the Command_t structure was returned to the pool, otherwise false.
+ */
+bool Agent_ReleaseCommand( Command_t * pCommandToRelease );
+
+#endif /* FREERTOS_COMMAND_POOL_H */

--- a/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.h
+++ b/lib/FreeRTOS/mqtt-agent-interface/freertos_command_pool.h
@@ -35,6 +35,11 @@
 #include "mqtt_agent.h"
 
 /**
+ * @brief Initialize the common task pool. Not thread safe.
+ */
+void Agent_InitializePool( void );
+
+/**
  * @brief Obtain a Command_t structure from the pool of structures managed by the agent.
  *
  * @note Command_t structures hold everything the MQTT agent needs to process a

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -74,6 +74,10 @@
 /* MQTT agent include. */
 #include "mqtt_agent.h"
 
+/* MQTT Agent ports. */
+#include "freertos_agent_message.h"
+#include "freertos_command_pool.h"
+
 /* Exponential backoff retry include. */
 #include "backoff_algorithm.h"
 
@@ -406,12 +410,24 @@ static MQTTStatus_t prvMQTTInit( void )
     MQTTFixedBuffer_t xFixedBuffer = { .pBuffer = xNetworkBuffer, .size = MQTT_AGENT_NETWORK_BUFFER_SIZE };
     static uint8_t staticQueueStorageArea[ MQTT_AGENT_COMMAND_QUEUE_LENGTH * sizeof( Command_t * ) ];
     static StaticQueue_t staticQueueStructure;
+    AgentMessageInterface_t messageInterface = {
+        .pMsgCtx = NULL,
+        .send = Agent_MessageSend,
+        .recv = Agent_MessageReceive,
+        .getCommand = Agent_GetCommand,
+        .releaseCommand = Agent_ReleaseCommand
+    };
 
     LogDebug( ( "Creating command queue." ) );
     xCommandQueue.queue = xQueueCreateStatic( MQTT_AGENT_COMMAND_QUEUE_LENGTH,
                                               sizeof( Command_t * ),
                                               staticQueueStorageArea,
                                               &staticQueueStructure );
+    configASSERT( xCommandQueue.queue );
+    messageInterface.pMsgCtx = &xCommandQueue;
+
+    /* Initialize the task pool. */
+    Agent_InitializePool();
 
     /* Fill in Transport Interface send and receive function pointers. */
     xTransport.pNetworkContext = &xNetworkContext;
@@ -425,7 +441,7 @@ static MQTTStatus_t prvMQTTInit( void )
 
     /* Initialize MQTT library. */
     xReturn = MQTTAgent_Init( &xGlobalMqttAgentContext,
-                              &xCommandQueue,
+                              &messageInterface,
                               &xFixedBuffer,
                               &xTransport,
                               prvGetTimeMs,

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -775,6 +775,7 @@ static BaseType_t prvSocketDisconnect( NetworkContext_t * pxNetworkContext )
 
 static void prvMQTTClientSocketWakeupCallback( Socket_t pxSocket )
 {
+    static CommandInfo_t xCommandParams = { 0 };
     /* Just to avoid compiler warnings.  The socket is not used but the function
      * prototype cannot be changed because this is a callback function. */
     ( void ) pxSocket;
@@ -784,7 +785,8 @@ static void prvMQTTClientSocketWakeupCallback( Socket_t pxSocket )
     if( ( uxQueueMessagesWaiting( xCommandQueue.queue ) == 0U ) && ( FreeRTOS_recvcount( pxSocket ) > 0 ) )
     {
         /* Don't block as this is called from the context of the IP task. */
-        MQTTAgent_TriggerProcessLoop( &xGlobalMqttAgentContext, 0 );
+        xCommandParams.blockTimeMs = 0U;
+        MQTTAgent_ProcessLoop( &xGlobalMqttAgentContext, &xCommandParams );
     }
 }
 

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -775,7 +775,7 @@ static BaseType_t prvSocketDisconnect( NetworkContext_t * pxNetworkContext )
 
 static void prvMQTTClientSocketWakeupCallback( Socket_t pxSocket )
 {
-    static CommandInfo_t xCommandParams = { 0 };
+    CommandInfo_t xCommandParams = { 0 };
     /* Just to avoid compiler warnings.  The socket is not used but the function
      * prototype cannot be changed because this is a callback function. */
     ( void ) pxSocket;

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -194,13 +194,6 @@
 
 /*-----------------------------------------------------------*/
 
-struct AgentMessageContext
-{
-    QueueHandle_t queue;
-};
-
-/*-----------------------------------------------------------*/
-
 /**
  * @brief Initializes an MQTT context, including transport interface and
  * network buffer.


### PR DESCRIPTION
*Description*:
Updates the MQTT agent submodule and adds back the FreeRTOS specific files for the queue and command pool. Also, changes the command pool implementation to use a single static queue instead of an array of binary semaphores, as it uses about 80% less memory.

- Update MQTT agent submodule
- Add files removed from MQTT agent
- Change command pool to queue and add VS files
