### PR TITLE
Add shadow demo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "lib/FreeRTOS/coreMQTT-Agent"]
 	path = lib/FreeRTOS/coreMQTT-Agent
 	url = https://github.com/FreeRTOS/coreMQTT-Agent.git
+[submodule "lib/AWS/shadow"]
+	path = lib/AWS/shadow
+	url = https://github.com/aws/Device-Shadow-for-AWS-IoT-embedded-sdk

--- a/build/VisualStudio/WIN32.vcxproj
+++ b/build/VisualStudio/WIN32.vcxproj
@@ -20,6 +20,7 @@
     <ClCompile Include="..\..\lib\AWS\ota\source\ota_interface.c" />
     <ClCompile Include="..\..\lib\AWS\ota\source\ota_mqtt.c" />
     <ClCompile Include="..\..\lib\AWS\ota\source\portable\os\ota_os_freertos.c" />
+    <ClCompile Include="..\..\lib\AWS\shadow\source\shadow.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\coreJSON\source\core_json.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\core_mqtt.c" />
     <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\core_mqtt_serializer.c" />
@@ -62,6 +63,9 @@
     <ClCompile Include="..\..\source\logging_output_windows.c" />
     <ClCompile Include="..\..\source\main.c" />
     <ClCompile Include="..\..\source\connection_manager.c" />
+    <ClCompile Include="..\..\source\shadow-tasks\shadow_device_task.c" />
+    <ClCompile Include="..\..\source\shadow-tasks\shadow_update_task.c" />
+    <ClCompile Include="..\..\source\shadow_demo.c" />
     <ClCompile Include="..\..\source\simple_sub_pub_demo.c" />
     <ClCompile Include="..\..\lib\ThirdParty\tinycbor\src\cborencoder.c" />
     <ClCompile Include="..\..\lib\ThirdParty\tinycbor\src\cborencoder_close_container_checked.c" />
@@ -79,6 +83,8 @@
     <ClInclude Include="..\..\lib\AWS\defender\source\include\defender_config_defaults.h" />
     <ClInclude Include="..\..\lib\AWS\ota-pal\Win32\ota_pal.h" />
     <ClInclude Include="..\..\lib\AWS\ota\source\portable\os\ota_os_freertos.h" />
+    <ClInclude Include="..\..\lib\AWS\shadow\source\include\shadow.h" />
+    <ClInclude Include="..\..\lib\AWS\shadow\source\include\shadow_config_defaults.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\coreJSON\source\include\core_json.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\include\core_mqtt.h" />
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\include\core_mqtt_config_defaults.h" />
@@ -137,6 +143,7 @@
     <ClInclude Include="..\..\source\configuration-files\FreeRTOSIPConfig.h" />
     <ClInclude Include="..\..\source\configuration-files\mbedtls_config.h" />
     <ClInclude Include="..\..\source\configuration-files\ota_config.h" />
+    <ClInclude Include="..\..\source\configuration-files\shadow_config.h" />
     <ClInclude Include="..\..\source\defender-tools\metrics_collector.h" />
     <ClInclude Include="..\..\source\defender-tools\report_builder.h" />
     <ClInclude Include="..\..\source\subscription-manager\subscription_manager.h" />
@@ -197,7 +204,7 @@
     </Midl>
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..\..\lib\AWS;..\..\lib\FreeRTOS\utilities\crypto\include;..\..\lib\AWS\ota-pal\Win32;..\..\lib\ThirdParty\tinycbor\src;..\..\lib\FreeRTOS\coreJSON\source\include;..\..\lib\AWS\ota\source\portable\os;..\..\lib\AWS\ota\source\include;..\..\lib\AWS\defender\source\include;..\..\lib\FreeRTOS\utilities\mbedtls_freertos;..\..\lib\FreeRTOS\utilities\backoffAlgorithm\source\include;..\..\lib\ThirdParty\mbedtls\include;..\..\lib\FreeRTOS\coreMQTT-Agent\source\include;..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface;..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\include;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp;..\..\lib\FreeRTOS\utilities\logging;..\..\lib\FreeRTOS\freertos-plus-tcp\include;..\..\lib\FreeRTOS\freertos-plus-tcp\tools\tcp_utilities\include;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp\using_mbedtls;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp\using_plaintext;..\..\lib\FreeRTOS\freertos-plus-tcp\portable\Compiler\MSVC;..\..\source\subscription-manager;..\..\source\configuration-files;..\..\source\defender-tools;..\..\lib\FreeRTOS\freertos-kernel\portable\MSVC-MingW;..\..\lib\FreeRTOS\freertos-kernel\include;..\..\lib\ThirdParty\WinPCap;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\lib\AWS;..\..\lib\FreeRTOS\utilities\crypto\include;..\..\lib\AWS\ota-pal\Win32;..\..\lib\ThirdParty\tinycbor\src;..\..\lib\FreeRTOS\coreJSON\source\include;..\..\lib\AWS\ota\source\portable\os;..\..\lib\AWS\ota\source\include;..\..\lib\AWS\defender\source\include;..\..\lib\AWS\shadow\source\include;..\..\lib\FreeRTOS\utilities\mbedtls_freertos;..\..\lib\FreeRTOS\utilities\backoffAlgorithm\source\include;..\..\lib\ThirdParty\mbedtls\include;..\..\lib\FreeRTOS\coreMQTT-Agent\source\include;..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface;..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\include;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp;..\..\lib\FreeRTOS\utilities\logging;..\..\lib\FreeRTOS\freertos-plus-tcp\include;..\..\lib\FreeRTOS\freertos-plus-tcp\tools\tcp_utilities\include;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp\using_mbedtls;..\..\lib\FreeRTOS\network_transport\freertos_plus_tcp\using_plaintext;..\..\lib\FreeRTOS\freertos-plus-tcp\portable\Compiler\MSVC;..\..\source\subscription-manager;..\..\source\configuration-files;..\..\source\defender-tools;..\..\lib\FreeRTOS\freertos-kernel\portable\MSVC-MingW;..\..\lib\FreeRTOS\freertos-kernel\include;..\..\lib\ThirdParty\WinPCap;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>MBEDTLS_CONFIG_FILE="mbedtls_config.h";WIN32;_DEBUG;_CONSOLE;_WIN32_WINNT=0x0500;WINVER=0x400;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>false</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>

--- a/build/VisualStudio/WIN32.vcxproj.filters
+++ b/build/VisualStudio/WIN32.vcxproj.filters
@@ -165,14 +165,15 @@
     </Filter>
     <Filter Include="Lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface">
       <UniqueIdentifier>{d852f1f2-242b-4f62-a469-bc8f51e6d5a4}</UniqueIdentifier>
+    </Filter>
     <Filter Include="Lib\AWS\Shadow">
-      <UniqueIdentifier>{a3b4d669-d865-4b94-9b80-3a9ec708d988}</UniqueIdentifier>
+      <UniqueIdentifier>{52c9068b-79db-472b-8235-31e3b99dde36}</UniqueIdentifier>
     </Filter>
     <Filter Include="Lib\AWS\Shadow\include">
-      <UniqueIdentifier>{2cc27d3e-1360-4472-8952-6a36a5bb4e4a}</UniqueIdentifier>
+      <UniqueIdentifier>{ff129ac5-3c99-4ce5-8968-5b9433332808}</UniqueIdentifier>
     </Filter>
     <Filter Include="Source\shadow-tasks">
-      <UniqueIdentifier>{236406e0-98b2-48be-9cce-e4b0abd9bb33}</UniqueIdentifier>
+      <UniqueIdentifier>{66473abe-6956-449b-904a-fd3d655083c5}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -361,16 +362,17 @@
     </ClCompile>
     <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\core_mqtt_state.c">
       <Filter>Lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\lib\AWS\shadow\source\shadow.c">
       <Filter>Lib\AWS\Shadow</Filter>
     </ClCompile>
     <ClCompile Include="..\..\source\shadow_demo.c">
       <Filter>Source</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\shadow-tasks\shadow_update_task.c">
+    <ClCompile Include="..\..\source\shadow-tasks\shadow_device_task.c">
       <Filter>Source\shadow-tasks</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\source\shadow-tasks\shadow_device_task.c">
+    <ClCompile Include="..\..\source\shadow-tasks\shadow_update_task.c">
       <Filter>Source\shadow-tasks</Filter>
     </ClCompile>
   </ItemGroup>
@@ -569,10 +571,11 @@
     </ClInclude>
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface\transport_interface.h">
       <Filter>Lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface</Filter>
-    <ClInclude Include="..\..\lib\AWS\shadow\source\include\shadow_config_defaults.h">
-      <Filter>Lib\AWS\Shadow\include</Filter>
     </ClInclude>
     <ClInclude Include="..\..\lib\AWS\shadow\source\include\shadow.h">
+      <Filter>Lib\AWS\Shadow\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\AWS\shadow\source\include\shadow_config_defaults.h">
       <Filter>Lib\AWS\Shadow\include</Filter>
     </ClInclude>
     <ClInclude Include="..\..\source\configuration-files\shadow_config.h">

--- a/build/VisualStudio/WIN32.vcxproj.filters
+++ b/build/VisualStudio/WIN32.vcxproj.filters
@@ -165,6 +165,14 @@
     </Filter>
     <Filter Include="Lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface">
       <UniqueIdentifier>{d852f1f2-242b-4f62-a469-bc8f51e6d5a4}</UniqueIdentifier>
+    <Filter Include="Lib\AWS\Shadow">
+      <UniqueIdentifier>{a3b4d669-d865-4b94-9b80-3a9ec708d988}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Lib\AWS\Shadow\include">
+      <UniqueIdentifier>{2cc27d3e-1360-4472-8952-6a36a5bb4e4a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source\shadow-tasks">
+      <UniqueIdentifier>{236406e0-98b2-48be-9cce-e4b0abd9bb33}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
@@ -353,6 +361,17 @@
     </ClCompile>
     <ClCompile Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\core_mqtt_state.c">
       <Filter>Lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source</Filter>
+    <ClCompile Include="..\..\lib\AWS\shadow\source\shadow.c">
+      <Filter>Lib\AWS\Shadow</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\source\shadow_demo.c">
+      <Filter>Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\source\shadow-tasks\shadow_update_task.c">
+      <Filter>Source\shadow-tasks</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\source\shadow-tasks\shadow_device_task.c">
+      <Filter>Source\shadow-tasks</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -550,6 +569,14 @@
     </ClInclude>
     <ClInclude Include="..\..\lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface\transport_interface.h">
       <Filter>Lib\FreeRTOS\coreMQTT-Agent\source\dependency\coreMQTT\source\interface</Filter>
+    <ClInclude Include="..\..\lib\AWS\shadow\source\include\shadow_config_defaults.h">
+      <Filter>Lib\AWS\Shadow\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\lib\AWS\shadow\source\include\shadow.h">
+      <Filter>Lib\AWS\Shadow\include</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\source\configuration-files\shadow_config.h">
+      <Filter>Configuration Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/source/configuration-files/demo_config.h
+++ b/source/configuration-files/demo_config.h
@@ -84,7 +84,8 @@ extern void vLoggingPrintf( const char * pcFormatString,
 #define democonfigCREATE_DEFENDER_DEMO                     1
 #define democonfigDEFENDER_TASK_STACK_SIZE                 ( configMINIMAL_STACK_SIZE )
 
-
+#define democonfigCREATE_SHADOW_DEMO                       1
+#define democonfigSHADOW_TASK_STACK_SIZE                   ( configMINIMAL_STACK_SIZE )
 
 /**
  * @brief The MQTT client identifier used in this example.  Each client identifier

--- a/source/configuration-files/shadow_config.h
+++ b/source/configuration-files/shadow_config.h
@@ -1,0 +1,64 @@
+/*
+ * AWS IoT Device SDK for Embedded C V202009.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef SHADOW_CONFIG_H
+#define SHADOW_CONFIG_H
+
+/**************************************************/
+/******* DO NOT CHANGE the following order ********/
+/**************************************************/
+
+/* Logging related header files are required to be included in the following order:
+ * 1. Include the header file "logging_levels.h".
+ * 2. Define LIBRARY_LOG_NAME and  LIBRARY_LOG_LEVEL.
+ * 3. Include the header file "logging_stack.h".
+ */
+
+/* Include header that defines log levels. */
+#include "logging_levels.h"
+
+/* Configure name and log level for the Shadow library. */
+#ifndef LIBRARY_LOG_NAME
+    #define LIBRARY_LOG_NAME     "SHADOW"
+#endif
+#ifndef LIBRARY_LOG_LEVEL
+    #define LIBRARY_LOG_LEVEL    LOG_INFO
+#endif
+
+/* Prototype for the function used to print to console on Windows simulator
+ * of FreeRTOS.
+ * The function prints to the console before the network is connected;
+ * then a UDP port after the network has connected. */
+extern void vLoggingPrintf( const char * pcFormatString,
+                            ... );
+
+/* Map the SdkLog macro to the logging function to enable logging
+ * on Windows simulator. */
+#ifndef SdkLog
+    #define SdkLog( message )    vLoggingPrintf message
+#endif
+
+#include "logging_stack.h"
+
+/************ End of logging configuration ****************/
+
+#endif /* ifndef SHADOW_CONFIG_H */

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -346,6 +346,9 @@ extern bool vOTAProcessMessage( void * pvIncomingPublishCallbackContext,
 
 extern void vStartDefenderDemo( configSTACK_DEPTH_TYPE uxStackSize,
                                 UBaseType_t uxPriority );
+
+extern void vStartShadowDemo(configSTACK_DEPTH_TYPE uxStackSize,
+   UBaseType_t uxPriority);
 /*-----------------------------------------------------------*/
 
 /**
@@ -939,6 +942,13 @@ static void prvConnectAndCreateDemoTasks( void * pvParameters )
                                 tskIDLE_PRIORITY );
         }
     #endif
+
+#if ( democonfigCREATE_SHADOW_DEMO == 1 )
+        {
+           vStartShadowDemo(democonfigSHADOW_TASK_STACK_SIZE,
+              tskIDLE_PRIORITY);
+        }
+#endif
 
     /* This task has nothing left to do, so rather than create the MQTT
      * agent as a separate thread, it simply calls the function that implements

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -123,6 +123,14 @@
     #error Please define democonfigDEFENDER_TASK_STACK_SIZE in demo_config.h to set the stack size (in words, not bytes) for the task created by vStartDefenderDemo().
 #endif
 
+#ifndef democonfigCREATE_SHADOW_DEMO
+    #error Please define democonfigCREATE_SHADOW_DEMO to 1 or 0 in demo_config.h - determines if vStartShadowDemo() gets called or not.
+#endif
+
+#if ( democonfigCREATE_SHADOW_DEMO != 0 ) && !defined( democonfigSHADOW_TASK_STACK_SIZE )
+    #error Please define democonfigSHADOW_TASK_STACK_SIZE in demo_config.h to set the stack size (in words, not bytes) for the tasks created by vStartShadowDemo().
+#endif
+
 /**
  * @brief Dimensions the buffer used to serialize and deserialize MQTT packets.
  * @note Specified in bytes.  Must be large enough to hold the maximum

--- a/source/connection_manager.c
+++ b/source/connection_manager.c
@@ -355,8 +355,8 @@ extern bool vOTAProcessMessage( void * pvIncomingPublishCallbackContext,
 extern void vStartDefenderDemo( configSTACK_DEPTH_TYPE uxStackSize,
                                 UBaseType_t uxPriority );
 
-extern void vStartShadowDemo(configSTACK_DEPTH_TYPE uxStackSize,
-   UBaseType_t uxPriority);
+extern void vStartShadowDemo( configSTACK_DEPTH_TYPE uxStackSize,
+                              UBaseType_t uxPriority );
 /*-----------------------------------------------------------*/
 
 /**
@@ -951,12 +951,12 @@ static void prvConnectAndCreateDemoTasks( void * pvParameters )
         }
     #endif
 
-#if ( democonfigCREATE_SHADOW_DEMO == 1 )
+    #if ( democonfigCREATE_SHADOW_DEMO == 1 )
         {
-           vStartShadowDemo(democonfigSHADOW_TASK_STACK_SIZE,
-              tskIDLE_PRIORITY);
+            vStartShadowDemo( democonfigSHADOW_TASK_STACK_SIZE,
+                              tskIDLE_PRIORITY );
         }
-#endif
+    #endif
 
     /* This task has nothing left to do, so rather than create the MQTT
      * agent as a separate thread, it simply calls the function that implements

--- a/source/shadow-tasks/shadow_device_task.c
+++ b/source/shadow-tasks/shadow_device_task.c
@@ -1,0 +1,799 @@
+/*
+ * FreeRTOS V202012.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/*
+ * Demo for showing how to use the Device Shadow library's API. This version
+ * of the Device Shadow API provides macros and helper functions for assembling MQTT topics
+ * strings, and for determining whether an incoming MQTT message is related to the
+ * device shadow.
+ *
+ * This example assumes there is a powerOn state in the device shadow. It does the
+ * following operations:
+ * 1. Assemble strings for the MQTT topics of device shadow, by using macros defined by the Device Shadow library.
+ * 2. Subscribe to those MQTT topics using the MQTT Agent.
+ * 3. Register callbacks for incoming shadow topic publishes with the subsciption_manager.
+ * 3. Publish to report the current state of powerOn.
+ * 5. Check if powerOn has been changed and send an update if so.
+ * 6. If a publish to update reported state was sent, wait until either prvIncomingPublishUpdateAcceptedCallback
+ *    or prvIncomingPublishUpdateRejectedCallback handle the response.
+ * 7. Wait until time for next check and repeat from step 5.
+ *
+ * Meanwhile, when prvIncomingPublishUpdateDeltaCallback recives changes to shadow state, it will apply them on the
+ * device
+ */
+
+/* Standard includes. */
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* Demo config. */
+#include "demo_config.h"
+
+/* MQTT library includes. */
+#include "mqtt_agent.h"
+
+/* Subscription manager header include. */
+#include "subscription_manager.h"
+
+/* JSON library includes. */
+#include "core_json.h"
+
+/* Shadow API header. */
+#include "shadow.h"
+
+/**
+ * democonfigCLIENT_IDENTIFIER is required. Throw compilation error if it is not defined.
+ */
+#ifndef democonfigCLIENT_IDENTIFIER
+    #error "Please define democonfigCLIENT_IDENTIFIER in demo_config.h to the thing name registered with AWS IoT Core."
+#endif
+
+/**
+ * @brief Format string representing a Shadow document with a "reported" state.
+ *
+ * The real json document will look like this:
+ * {
+ *   "state": {
+ *     "reported": {
+ *       "powerOn": 1
+ *     }
+ *   },
+ *   "clientToken": "021909"
+ * }
+ *
+ * Note the client token, which is required for all Shadow updates. The client
+ * token must be unique at any given time, but may be reused once the update is
+ * completed. For this demo, a timestamp is used for a client token.
+ */
+#define shadowexampleSHADOW_REPORTED_JSON \
+    "{"                                   \
+    "\"state\":{"                         \
+    "\"reported\":{"                      \
+    "\"powerOn\":%01u"                    \
+    "}"                                   \
+    "},"                                  \
+    "\"clientToken\":\"%06lu\""           \
+    "}"
+
+/**
+ * @brief The expected size of #SHADOW_REPORTED_JSON.
+ *
+ * Because all the format specifiers in #SHADOW_REPORTED_JSON include a length,
+ * its full size is known at compile-time by pre-calculation.
+ *
+ * Because all the format specifiers in #SHADOW_REPORTED_JSON include a length,
+ * its full actual size is known by pre-calculation, here's the formula why
+ * the length need to minus 3:
+ * 1. The length of "%01d" is 4.
+ * 2. The length of %06lu is 5.
+ * 3. The actual length we will use in case 1. is 1 ( for the state of powerOn ).
+ * 4. The actual length we will use in case 2. is 6 ( for the clientToken length ).
+ * 5. Thus the additional size 3 = 4 + 5 - 1 - 6 + 1 (termination character).
+ *
+ * In your own application, you could calculate the size of the json doc in this way.
+ */
+#define shadowexampleSHADOW_REPORTED_JSON_LENGTH       ( sizeof( shadowexampleSHADOW_REPORTED_JSON ) - 3 )
+
+/**
+ * @brief Time in ms to wait between checking for updates to report.
+ */
+#define shadowexampleMS_BETWEEN_REPORTS                ( 15000U )
+
+/**
+ * @brief This demo uses task notifications to signal tasks from MQTT callback
+ * functions. shadowexampleMS_TO_WAIT_FOR_NOTIFICATION defines the time, in ticks,
+ * to wait for such a callback.
+ */
+#define shadowexampleMS_TO_WAIT_FOR_NOTIFICATION       ( 5000 )
+
+/**
+ * @brief The maximum amount of time in milliseconds to wait for the commands
+ * to be posted to the MQTT agent should the MQTT agent's command queue be full.
+ * Tasks wait in the Blocked state, so don't use any CPU time.
+ */
+#define shadowexampleMAX_COMMAND_SEND_BLOCK_TIME_MS    ( 200 )
+
+/**
+ * @brief Defines the structure to use as the command callback context in this
+ * demo.
+ */
+struct CommandContext
+{
+    MQTTStatus_t xReturnStatus;
+    TaskHandle_t xTaskToNotify;
+};
+
+extern MQTTAgentContext_t xGlobalMqttAgentContext;
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The simulated device current power on state.
+ */
+static uint32_t ulCurrentPowerOnState = 0;
+
+/**
+ * @brief The last reported state. It is initialized to and invalid value so that
+ * an update is initially sent.
+ */
+static uint32_t ulReportedPowerOnState = 2;
+
+/**
+ * @brief When we send an update to the device shadow, and if we care about
+ * the response from cloud (accepted/rejected), remember the clientToken and
+ * use it to match with the response. We set this to 0 when not waiting on a
+ * response.
+ */
+static uint32_t ulClientToken = 0U;
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Subscribe to the used device shadow topics.
+ *
+ * @return true if the subscribe is successful;
+ * false otherwise.
+ */
+static bool prvSubscribeToShadowUpdateTopics( void );
+
+/**
+ * @brief Passed into MQTTAgent_Subscribe() as the callback to execute when the
+ * broker ACKs the SUBSCRIBE message.  Its implementation sends a notification
+ * to the task that called MQTTAgent_Subscribe() to let the task know the
+ * SUBSCRIBE operation completed.  It also sets the xReturnStatus of the
+ * structure passed in as the command's context to the value of the
+ * xReturnStatus parameter - which enables the task to check the status of the
+ * operation.
+ *
+ * See https://freertos.org/mqtt/mqtt-agent-demo.html#example_mqtt_api_call
+ *
+ * @param[in] pxCommandContext Context of the initial command.
+ * @param[in] pxReturnInfo The result of the command.
+ */
+static void prvSubscribeCommandCallback( void * pxCommandContext,
+                                         MQTTAgentReturnInfo_t * pxReturnInfo );
+
+/**
+ * @brief The callback to execute when there is an incoming publish on the
+ * topic for delta updates. It verifies the document and sets the
+ * powerOn state accordingly.
+ *
+ * @param[in] pvIncomingPublishCallbackContext Context of the initial command.
+ * @param[in] pxPublishInfo Deserialized publish.
+ */
+static void prvIncomingPublishUpdateDeltaCallback( void * pxSubscriptionContext,
+                                                   MQTTPublishInfo_t * pxPublishInfo );
+
+/**
+ * @brief The callback to execute when there is an incoming publish on the
+ * topic for accepted requests. It verifies the document is valid and is being waited on.
+ * If so it updates the last reported state and notifies the task to inform completion
+ * of the update request.
+ *
+ * @param[in] pvIncomingPublishCallbackContext Context of the initial command.
+ * @param[in] pxPublishInfo Deserialized publish.
+ */
+static void prvIncomingPublishUpdateAcceptedCallback( void * pxSubscriptionContext,
+                                                      MQTTPublishInfo_t * pxPublishInfo );
+
+
+/**
+ * @brief The callback to execute when there is an incoming publish on the
+ * topic for rejected requests. It verifies the document is valid and is being waited on.
+ * If so it notifies the task to inform completion of the update request.
+ *
+ * @param[in] pvIncomingPublishCallbackContext Context of the initial command.
+ * @param[in] pxPublishInfo Deserialized publish.
+ */
+static void prvIncomingPublishUpdateRejectedCallback( void * pxSubscriptionContext,
+                                                      MQTTPublishInfo_t * pxPublishInfo );
+
+/**
+ * @brief Entry point of shadow demo.
+ *
+ * This main function demonstrates how to use the macros provided by the
+ * Device Shadow library to assemble strings for the MQTT topics defined
+ * by AWS IoT Device Shadow. It uses these macros for topics to subscribe
+ * to:
+ * - SHADOW_TOPIC_STRING_UPDATE_DELTA for "$aws/things/thingName/shadow/update/delta"
+ * - SHADOW_TOPIC_STRING_UPDATE_ACCEPTED for "$aws/things/thingName/shadow/update/accepted"
+ * - SHADOW_TOPIC_STRING_UPDATE_REJECTED for "$aws/things/thingName/shadow/update/rejected"
+ *
+ * It also uses these macros for topics to publish to:
+ * - SHADOW_TOPIC_STIRNG_DELETE for "$aws/things/thingName/shadow/delete"
+ * - SHADOW_TOPIC_STRING_UPDATE for "$aws/things/thingName/shadow/update"
+ */
+void vShadowDeviceTask( void * pvParameters );
+
+/*-----------------------------------------------------------*/
+
+static bool prvSubscribeToShadowUpdateTopics( void )
+{
+    bool xReturnStatus = true;
+    MQTTStatus_t xStatus;
+    uint32_t ulNotificationValue;
+    CommandInfo_t xCommandParams = { 0 };
+
+    /* These must persist until the command is processed. */
+    static MQTTAgentSubscribeArgs_t xSubscribeArgs;
+    static MQTTSubscribeInfo_t xSubscribeInfo[ 3 ];
+
+    /* Context must persist as long as subscription persists. */
+    static CommandContext_t xApplicationDefinedContext = { 0 };
+
+    /* Record the handle of this task in the context that will be used within
+    * the callbacks so the callbacks can send a notification to this task. */
+    xApplicationDefinedContext.xTaskToNotify = xTaskGetCurrentTaskHandle();
+
+    /* Ensure the return status is not accidentally MQTTSuccess already. */
+    xApplicationDefinedContext.xReturnStatus = MQTTBadParameter;
+
+    /* Subscribe to shadow topic for responses for incoming delta updates. */
+    xSubscribeInfo[ 0 ].pTopicFilter = SHADOW_TOPIC_STRING_UPDATE_DELTA( democonfigCLIENT_IDENTIFIER );
+    xSubscribeInfo[ 0 ].topicFilterLength = SHADOW_TOPIC_LENGTH_UPDATE_DELTA( democonfigCLIENT_IDENTIFIER_LENGTH );
+    xSubscribeInfo[ 0 ].qos = MQTTQoS1;
+    /* Subscribe to shadow topic for accepted responses for submitted updates. */
+    xSubscribeInfo[ 1 ].pTopicFilter = SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER );
+    xSubscribeInfo[ 1 ].topicFilterLength = SHADOW_TOPIC_LENGTH_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER_LENGTH );
+    xSubscribeInfo[ 1 ].qos = MQTTQoS1;
+    /* Subscribe to shadow topic for rejected responses for submitted updates. */
+    xSubscribeInfo[ 2 ].pTopicFilter = SHADOW_TOPIC_STRING_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER );
+    xSubscribeInfo[ 2 ].topicFilterLength = SHADOW_TOPIC_LENGTH_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER_LENGTH );
+    xSubscribeInfo[ 2 ].qos = MQTTQoS1;
+
+    /* Complete the subscribe information.  The topic string must persist for
+     * duration of subscription - although in this case is it a static const so
+     * will persist for the lifetime of the application. */
+    xSubscribeArgs.pSubscribeInfo = xSubscribeInfo;
+    xSubscribeArgs.numSubscriptions = 3;
+
+    /* Loop in case the queue used to communicate with the MQTT agent is full and
+     * attempts to post to it time out.  The queue will not become full if the
+     * priority of the MQTT agent task is higher than the priority of the task
+     * calling this function. */
+    xTaskNotifyStateClear( NULL );
+    xCommandParams.blockTimeMs = shadowexampleMAX_COMMAND_SEND_BLOCK_TIME_MS;
+    xCommandParams.cmdCompleteCallback = prvSubscribeCommandCallback;
+    xCommandParams.pCmdCompleteCallbackContext = &xApplicationDefinedContext;
+    LogInfo( ( "Sending subscribe request to agent for defender topics." ) );
+
+    do
+    {
+        /* If this fails, the agent's queue is full, so we retry until the agent
+         * has more space in the queue. */
+        xStatus = MQTTAgent_Subscribe( &xGlobalMqttAgentContext,
+                                       &( xSubscribeArgs ),
+                                       &xCommandParams );
+    } while( xStatus != MQTTSuccess );
+
+    /* Wait for acks from subscribe messages - this is optional.  If the
+     * returned value is zero then the wait timed out. */
+    ulNotificationValue = ulTaskNotifyTake( pdFALSE, pdMS_TO_TICKS( shadowexampleMS_TO_WAIT_FOR_NOTIFICATION ) );
+    configASSERT( ulNotificationValue != 0UL );
+
+    /* The callback sets the xReturnStatus member of the context. */
+    if( xApplicationDefinedContext.xReturnStatus != MQTTSuccess )
+    {
+        LogError( ( "Failed to subscribe to shadow update topics." ) );
+        xReturnStatus = false;
+    }
+    else
+    {
+        LogInfo( ( "Received subscribe ack for shadow update topics." ) );
+    }
+
+    /* Add subscriptions so that incoming publishes are routed to the application
+     * callback. */
+    if( xReturnStatus == true )
+    {
+        xReturnStatus = addSubscription( ( SubscriptionElement_t * ) xGlobalMqttAgentContext.pIncomingCallbackContext,
+                                         SHADOW_TOPIC_STRING_UPDATE_DELTA( democonfigCLIENT_IDENTIFIER ),
+                                         SHADOW_TOPIC_LENGTH_UPDATE_DELTA( democonfigCLIENT_IDENTIFIER_LENGTH ),
+                                         prvIncomingPublishUpdateDeltaCallback,
+                                         &xApplicationDefinedContext );
+
+        if( xReturnStatus == false )
+        {
+            LogError( ( "Failed to register an incoming publish callback for topic %.*s.",
+                        SHADOW_TOPIC_LENGTH_UPDATE_DELTA( democonfigCLIENT_IDENTIFIER_LENGTH ),
+                        SHADOW_TOPIC_STRING_UPDATE_DELTA( democonfigCLIENT_IDENTIFIER ) ) );
+            xReturnStatus = false;
+        }
+    }
+
+    if( xReturnStatus == true )
+    {
+        xReturnStatus = addSubscription( ( SubscriptionElement_t * ) xGlobalMqttAgentContext.pIncomingCallbackContext,
+                                         SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER ),
+                                         SHADOW_TOPIC_LENGTH_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER_LENGTH ),
+                                         prvIncomingPublishUpdateAcceptedCallback,
+                                         &xApplicationDefinedContext );
+
+        if( xReturnStatus == false )
+        {
+            LogError( ( "Failed to register an incoming publish callback for topic %.*s.",
+                        SHADOW_TOPIC_LENGTH_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER_LENGTH ),
+                        SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER ) ) );
+            xReturnStatus = false;
+        }
+    }
+
+    if( xReturnStatus == true )
+    {
+        xReturnStatus = addSubscription( ( SubscriptionElement_t * ) xGlobalMqttAgentContext.pIncomingCallbackContext,
+                                         SHADOW_TOPIC_STRING_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER ),
+                                         SHADOW_TOPIC_LENGTH_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER_LENGTH ),
+                                         prvIncomingPublishUpdateRejectedCallback,
+                                         &xApplicationDefinedContext );
+
+        if( xReturnStatus == false )
+        {
+            LogError( ( "Failed to register an incoming publish callback for topic %.*s.",
+                        SHADOW_TOPIC_LENGTH_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER_LENGTH ),
+                        SHADOW_TOPIC_STRING_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER ) ) );
+            xReturnStatus = false;
+        }
+    }
+
+    return xReturnStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvSubscribeCommandCallback( void * pxCommandContext,
+                                         MQTTAgentReturnInfo_t * pxReturnInfo )
+{
+    CommandContext_t * pxApplicationDefinedContext = ( CommandContext_t * ) pxCommandContext;
+
+    /* Store the result in the application defined context so the calling task
+     * can check it. */
+    pxApplicationDefinedContext->xReturnStatus = pxReturnInfo->returnCode;
+
+    xTaskNotifyGive( pxApplicationDefinedContext->xTaskToNotify );
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvIncomingPublishUpdateDeltaCallback( void * pxSubscriptionContext,
+                                                   MQTTPublishInfo_t * pxPublishInfo )
+{
+    static uint32_t ulCurrentVersion = 0; /* Remember the latest version number we've received */
+    uint32_t ulVersion = 0U;
+    uint32_t ulNewState = 0U;
+    char * pcOutValue = NULL;
+    uint32_t ulOutValueLength = 0U;
+    JSONStatus_t result = JSONSuccess;
+    CommandContext_t * pxApplicationDefinedContext = ( CommandContext_t * ) pxSubscriptionContext;
+
+    configASSERT( pxPublishInfo != NULL );
+    configASSERT( pxPublishInfo->pPayload != NULL );
+
+    LogDebug( ( "/update/delta json payload:%s.", ( const char * ) pxPublishInfo->pPayload ) );
+
+    /* The payload will look similar to this:
+     * {
+     *      "state": {
+     *          "powerOn": 1
+     *      },
+     *      "metadata": {
+     *          "powerOn": {
+     *              "timestamp": 1595437367
+     *          }
+     *      },
+     *      "timestamp": 1595437367,
+     *      "clientToken": "388062",
+     *      "version": 12
+     *  }
+     */
+
+    /* Make sure the payload is a valid json document. */
+    result = JSON_Validate( pxPublishInfo->pPayload,
+                            pxPublishInfo->payloadLength );
+
+    if( result != JSONSuccess )
+    {
+        LogError( ( "Invalid JSON document recieved!" ) );
+    }
+    else
+    {
+        /* Obtain the version value. */
+        result = JSON_Search( ( char * ) pxPublishInfo->pPayload,
+                              pxPublishInfo->payloadLength,
+                              "version",
+                              sizeof( "version" ) - 1,
+                              &pcOutValue,
+                              ( size_t * ) &ulOutValueLength );
+
+        if( result != JSONSuccess )
+        {
+            LogError( ( "Version field not found in JSON document!" ) );
+        }
+        else
+        {
+            /* Convert the extracted value to an unsigned integer value. */
+            ulVersion = ( uint32_t ) strtoul( pcOutValue, NULL, 10 );
+
+            /* Make sure the version is newer than the last one we received. */
+            if( ulVersion <= ulCurrentVersion )
+            {
+                /* In this demo, we discard the incoming message
+                 * if the version number is not newer than the latest
+                 * that we've received before. Your application may use a
+                 * different approach.
+                 */
+                LogWarn( ( "Recieved unexpected delta update with version %u. Current version is %u", ( unsigned int ) ulVersion, ( unsigned int ) ulCurrentVersion ) );
+            }
+            else
+            {
+                LogInfo( ( "Recieved delta update with version %.*s.",
+                           ulOutValueLength,
+                           pcOutValue ) );
+
+                /* Set received version as the current version. */
+                ulCurrentVersion = ulVersion;
+
+                /* Get powerOn state from json documents. */
+                result = JSON_Search( ( char * ) pxPublishInfo->pPayload,
+                                      pxPublishInfo->payloadLength,
+                                      "state.powerOn",
+                                      sizeof( "state.powerOn" ) - 1,
+                                      &pcOutValue,
+                                      ( size_t * ) &ulOutValueLength );
+
+                if( result != JSONSuccess )
+                {
+                    LogError( ( "powerOn field not found in JSON document!" ) );
+                }
+                else
+                {
+                    /* Convert the powerOn state value to an unsigned integer value. */
+                    ulNewState = ( uint32_t ) strtoul( pcOutValue, NULL, 10 );
+
+                    LogInfo( ( "Setting powerOn state to %u.",
+                               ( unsigned int ) ulNewState ) );
+                    /* Set the new powerOn state. */
+                    ulCurrentPowerOnState = ulNewState;
+                }
+            }
+        }
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvIncomingPublishUpdateAcceptedCallback( void * pxSubscriptionContext,
+                                                      MQTTPublishInfo_t * pxPublishInfo )
+{
+    char * pcOutValue = NULL;
+    uint32_t ulOutValueLength = 0U;
+    uint32_t ulReceivedToken = 0U;
+    JSONStatus_t result = JSONSuccess;
+
+    CommandContext_t * pxApplicationDefinedContext = ( CommandContext_t * ) pxSubscriptionContext;
+
+    configASSERT( pxPublishInfo != NULL );
+    configASSERT( pxPublishInfo->pPayload != NULL );
+
+    LogDebug( ( "/update/accepted JSON payload: %s.", ( const char * ) pxPublishInfo->pPayload ) );
+
+    /* Handle the reported state with state change in /update/accepted topic.
+     * Thus we will retrieve the client token from the JSON document to see if
+     * it's the same one we sent with reported state on the /update topic.
+     * The payload will look similar to this:
+     *  {
+     *      "state": {
+     *          "reported": {
+     *             "powerOn": 1
+     *          }
+     *      },
+     *      "metadata": {
+     *          "reported": {
+     *              "powerOn": {
+     *                  "timestamp": 1596573647
+     *              }
+     *          }
+     *      },
+     *      "version": 14698,
+     *      "timestamp": 1596573647,
+     *      "clientToken": "022485"
+     *  }
+     */
+
+    /* Make sure the payload is a valid json document. */
+    result = JSON_Validate( pxPublishInfo->pPayload,
+                            pxPublishInfo->payloadLength );
+
+    if( result != JSONSuccess )
+    {
+        LogError( ( "Invalid JSON document recieved!" ) );
+    }
+    else
+    {
+        /* Get clientToken from json documents. */
+        result = JSON_Search( ( char * ) pxPublishInfo->pPayload,
+                              pxPublishInfo->payloadLength,
+                              "clientToken",
+                              sizeof( "clientToken" ) - 1,
+                              &pcOutValue,
+                              ( size_t * ) &ulOutValueLength );
+    }
+
+    if( result != JSONSuccess )
+    {
+        LogDebug( ( "Ignoring publish on /update/accepted with no clientToken field." ) );
+    }
+    else
+    {
+        /* Convert the code to an unsigned integer value. */
+        ulReceivedToken = ( uint32_t ) strtoul( pcOutValue, NULL, 10 );
+
+        /* If we are waiting for a response, ulClientToken will be the token for the response
+         * we are waiting for, else it will be 0. ulRecievedToken may not match if the response is
+         * not for us or if it is is a response that arrived after we timed out
+         * waiting for it.
+         */
+        if( ulReceivedToken != ulClientToken )
+        {
+            LogDebug( ( "Ignoring publish on /update/accepted with clientToken %lu.", ( unsigned long ) ulReceivedToken ) );
+        }
+        else
+        {
+            LogInfo( ( "Received accepted response for update with token %lu. ", ( unsigned long ) ulClientToken ) );
+
+            /*  Obtain the accepted state from the response and update our last sent state. */
+            result = JSON_Search( ( char * ) pxPublishInfo->pPayload,
+                                  pxPublishInfo->payloadLength,
+                                  "state.reported.powerOn",
+                                  sizeof( "state.reported.powerOn" ) - 1,
+                                  &pcOutValue,
+                                  ( size_t * ) &ulOutValueLength );
+
+            if( result != JSONSuccess )
+            {
+                LogError( ( "powerOn field not found in JSON document!" ) );
+            }
+            else
+            {
+                /* Convert the powerOn state value to an unsigned integer value and
+                 * save the new last reported value*/
+                ulReportedPowerOnState = ( uint32_t ) strtoul( pcOutValue, NULL, 10 );
+            }
+
+            /* Wake up the shadow task which is waiting for this response. */
+            xTaskNotifyGive( pxApplicationDefinedContext->xTaskToNotify );
+        }
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvIncomingPublishUpdateRejectedCallback( void * pxSubscriptionContext,
+                                                      MQTTPublishInfo_t * pxPublishInfo )
+{
+    JSONStatus_t result = JSONSuccess;
+    char * pcOutValue = NULL;
+    uint32_t ulOutValueLength = 0UL;
+    CommandContext_t * pxApplicationDefinedContext = ( CommandContext_t * ) pxSubscriptionContext;
+    uint32_t ulReceivedToken = 0U;
+
+    configASSERT( pxPublishInfo != NULL );
+    configASSERT( pxPublishInfo->pPayload != NULL );
+
+    LogDebug( ( "/update/rejected json payload: %s.", ( const char * ) pxPublishInfo->pPayload ) );
+
+    /* The payload will look similar to this:
+     * {
+     *    "code": error-code,
+     *    "message": "error-message",
+     *    "timestamp": timestamp,
+     *    "clientToken": "token"
+     * }
+     */
+
+    /* Make sure the payload is a valid json document. */
+    result = JSON_Validate( pxPublishInfo->pPayload,
+                            pxPublishInfo->payloadLength );
+
+    if( result != JSONSuccess )
+    {
+        LogError( ( "Invalid JSON document recieved!" ) );
+    }
+    else
+    {
+        /* Get clientToken from json documents. */
+        result = JSON_Search( ( char * ) pxPublishInfo->pPayload,
+                              pxPublishInfo->payloadLength,
+                              "clientToken",
+                              sizeof( "clientToken" ) - 1,
+                              &pcOutValue,
+                              ( size_t * ) &ulOutValueLength );
+    }
+
+    if( result != JSONSuccess )
+    {
+        LogDebug( ( "Ignoring publish on /update/rejected with clientToken %lu.", ( unsigned long ) ulReceivedToken ) );
+    }
+    else
+    {
+        /* Convert the code to an unsigned integer value. */
+        ulReceivedToken = ( uint32_t ) strtoul( pcOutValue, NULL, 10 );
+
+        /* If we are waiting for a response, ulClientToken will be the token for the response
+         * we are waiting for, else it will be 0. ulRecievedToken may not match if the response is
+         * not for us or if it is is a response that arrived after we timed out
+         * waiting for it.
+         */
+        if( ulReceivedToken != ulClientToken )
+        {
+            LogDebug( ( "Ignoring publish on /update/rejected with clientToken %lu.", ( unsigned long ) ulReceivedToken ) );
+        }
+        else
+        {
+            /*  Obtain the error code. */
+            result = JSON_Search( ( char * ) pxPublishInfo->pPayload,
+                                  pxPublishInfo->payloadLength,
+                                  "code",
+                                  sizeof( "code" ) - 1,
+                                  &pcOutValue,
+                                  ( size_t * ) &ulOutValueLength );
+
+            if( result != JSONSuccess )
+            {
+                LogWarn( ( "Received rejected response for update with token %lu and no error code.", ( unsigned long ) ulClientToken ) );
+            }
+            else
+            {
+                LogWarn( ( "Received rejected response for update with token %lu and error code %.*s.", ( unsigned long ) ulClientToken,
+                           ulOutValueLength,
+                           pcOutValue ) );
+            }
+
+            /* Wake up the shadow task which is waiting for this response. */
+            xTaskNotifyGive( pxApplicationDefinedContext->xTaskToNotify );
+        }
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+void vShadowDeviceTask( void * pvParameters )
+{
+    bool xStatus = true;
+    uint32_t ulNotificationValue;
+    static MQTTPublishInfo_t xPublishInfo = { 0 };
+    CommandInfo_t xCommandParams = { 0 };
+    MQTTStatus_t xCommandAdded;
+
+    /* A buffer containing the update document. It has static duration to prevent
+     * it from being placed on the call stack. */
+    static char pcUpdateDocument[ shadowexampleSHADOW_REPORTED_JSON_LENGTH + 1 ] = { 0 };
+
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
+
+    /* Set up the CommandInfo_t for the demo loop.
+     * We do not need a completion callback here since for publishes, we expect to get a
+     * response on the appropriate topics for accepted or rejected reports, and for pings
+     * we do not care about the completion. */
+    xCommandParams.blockTimeMs = shadowexampleMAX_COMMAND_SEND_BLOCK_TIME_MS;
+    xCommandParams.cmdCompleteCallback = NULL;
+
+    /* Set up MQTTPublishInfo_t for the update reports. */
+    xPublishInfo.qos = MQTTQoS1;
+    xPublishInfo.pTopicName = SHADOW_TOPIC_STRING_UPDATE( democonfigCLIENT_IDENTIFIER );
+    xPublishInfo.topicNameLength = SHADOW_TOPIC_LENGTH_UPDATE( democonfigCLIENT_IDENTIFIER_LENGTH );
+    xPublishInfo.pPayload = pcUpdateDocument;
+    xPublishInfo.payloadLength = ( shadowexampleSHADOW_REPORTED_JSON_LENGTH + 1 );
+
+    /* Subscribe to Shadow topics. */
+    xStatus = prvSubscribeToShadowUpdateTopics();
+
+    if( xStatus == true )
+    {
+        for( ; ; )
+        {
+            if( ulCurrentPowerOnState == ulReportedPowerOnState )
+            {
+                LogInfo( ( "No change in powerOn state since last report. Current state is %u.", ulCurrentPowerOnState ) );
+
+                MQTTAgent_Ping( &xGlobalMqttAgentContext,
+                                &xCommandParams );
+            }
+            else
+            {
+                LogInfo( ( "PowerOn state is now %u. Sending new report.", ( unsigned int ) ulCurrentPowerOnState ) );
+
+                /* Create a new client token and save it for use in the update accepted and rejected callbacks. */
+                ulClientToken = ( xTaskGetTickCount() % 1000000 );
+
+                /* Generate update report. */
+                ( void ) memset( pcUpdateDocument,
+                                 0x00,
+                                 sizeof( pcUpdateDocument ) );
+
+                snprintf( pcUpdateDocument,
+                          shadowexampleSHADOW_REPORTED_JSON_LENGTH + 1,
+                          shadowexampleSHADOW_REPORTED_JSON,
+                          ( unsigned int ) ulCurrentPowerOnState,
+                          ( long unsigned ) ulClientToken );
+
+                /* Send update. */
+                LogInfo( ( "Publishing to /update with following client token %lu.", ( long unsigned ) ulClientToken ) );
+                LogDebug( ( "Publish content: %.*s", shadowexampleSHADOW_REPORTED_JSON_LENGTH, pcUpdateDocument ) );
+
+                xCommandAdded = MQTTAgent_Publish( &xGlobalMqttAgentContext,
+                                                   &xPublishInfo,
+                                                   &xCommandParams );
+
+                /* Wait for the response to our report. */
+                ulNotificationValue = ulTaskNotifyTake( pdFALSE, pdMS_TO_TICKS( shadowexampleMS_TO_WAIT_FOR_NOTIFICATION ) );
+
+                if( ulNotificationValue == 0 )
+                {
+                    LogError( ( "Timed out waiting for response to report." ) );
+
+                    /* If we time out waiting for a response and then the report is accepted, the
+                     * state may be out of sync. Set the reported state as to ensure we resend the
+                     * report. */
+                    ulReportedPowerOnState = 2;
+                }
+
+                /* Clear the client token */
+                ulClientToken = 0;
+            }
+
+            LogDebug( ( "Sleeping until next update check." ) );
+            vTaskDelay( pdMS_TO_TICKS( shadowexampleMS_BETWEEN_REPORTS ) );
+        }
+    }
+}
+
+/*-----------------------------------------------------------*/

--- a/source/shadow-tasks/shadow_device_task.c
+++ b/source/shadow-tasks/shadow_device_task.c
@@ -744,6 +744,8 @@ void vShadowDeviceTask( void * pvParameters )
             {
                 LogInfo( ( "No change in powerOn state since last report. Current state is %u.", ulCurrentPowerOnState ) );
 
+                /* The following line is only needed for winsim. Due to an inaccurate tick rate, the connection
+                 * times out as the keepalive packets are not sent at the expected interval. */
                 MQTTAgent_Ping( &xGlobalMqttAgentContext,
                                 &xCommandParams );
             }

--- a/source/shadow-tasks/shadow_device_task.c
+++ b/source/shadow-tasks/shadow_device_task.c
@@ -303,7 +303,7 @@ static bool prvSubscribeToShadowUpdateTopics( void )
     xCommandParams.blockTimeMs = shadowexampleMAX_COMMAND_SEND_BLOCK_TIME_MS;
     xCommandParams.cmdCompleteCallback = prvSubscribeCommandCallback;
     xCommandParams.pCmdCompleteCallbackContext = &xApplicationDefinedContext;
-    LogInfo( ( "Sending subscribe request to agent for defender topics." ) );
+    LogInfo( ( "Sending subscribe request to agent for shadow topics." ) );
 
     do
     {

--- a/source/shadow-tasks/shadow_update_task.c
+++ b/source/shadow-tasks/shadow_update_task.c
@@ -270,7 +270,7 @@ static bool prvSubscribeToShadowUpdateTopics( void )
     xCommandParams.blockTimeMs = shadowexampleMAX_COMMAND_SEND_BLOCK_TIME_MS;
     xCommandParams.cmdCompleteCallback = prvSubscribeCommandCallback;
     xCommandParams.pCmdCompleteCallbackContext = &xApplicationDefinedContext;
-    LogInfo( ( "Sending subscribe request to agent for defender topics." ) );
+    LogInfo( ( "Sending subscribe request to agent for shadow topics." ) );
 
     do
     {

--- a/source/shadow-tasks/shadow_update_task.c
+++ b/source/shadow-tasks/shadow_update_task.c
@@ -1,0 +1,611 @@
+/*
+ * FreeRTOS V202012.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/*
+ * Demo task for requsting updates to a device shadow using the Device Shadow library's API.
+ * This task flips the powerOn state in the device shadow on a fixed interval.
+ *
+ * This example assumes there is a powerOn state in the device shadow. It does the
+ * following operations:
+ * 1. Assemble strings for the MQTT topics of device shadow, by using macros defined by the Device Shadow library.
+ * 2. Subscribe to those MQTT topics using the MQTT Agent.
+ * 3. Register callbacks for incoming shadow topic publishes with the subsciption_manager.
+ * 4. Wait until it is time to publish a requested change.
+ * 5. Publish a desired state of powerOn. That will cause a delta message to be sent to device.
+ * 6. Wait until either prvIncomingPublishUpdateAcceptedCallback or prvIncomingPublishUpdateRejectedCallback handle
+ *    the response.
+ * 7. Repeat from step 4.
+ */
+
+/* Standard includes. */
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* Demo config. */
+#include "demo_config.h"
+
+/* MQTT library includes. */
+#include "mqtt_agent.h"
+
+/* Subscription manager header include. */
+#include "subscription_manager.h"
+
+/* JSON library includes. */
+#include "core_json.h"
+
+/* Shadow API header. */
+#include "shadow.h"
+
+/**
+ * democonfigCLIENT_IDENTIFIER is required. Throw compilation error if it is not defined.
+ */
+#ifndef democonfigCLIENT_IDENTIFIER
+    #error "Please define democonfigCLIENT_IDENTIFIER in demo_config.h to the thing name registered with AWS IoT Core."
+#endif
+
+/**
+ * @brief Format string representing a Shadow document with a "desired" state.
+ *
+ * The real json document will look like this:
+ * {
+ *   "state": {
+ *     "desired": {
+ *       "powerOn": 1
+ *     }
+ *   },
+ *   "clientToken": "021909"
+ * }
+ *
+ * Note the client token, which is optional for all Shadow updates. The client
+ * token must be unique at any given time, but may be reused once the update is
+ * completed. For this demo, a timestamp is used for a client token.
+ */
+#define shadowexampleSHADOW_DESIRED_JSON \
+    "{"                                  \
+    "\"state\":{"                        \
+    "\"desired\":{"                      \
+    "\"powerOn\":%01d"                   \
+    "}"                                  \
+    "},"                                 \
+    "\"clientToken\":\"%06lu\""          \
+    "}"
+
+/**
+ * @brief The expected size of #SHADOW_DESIRED_JSON.
+ *
+ * Because all the format specifiers in #SHADOW_DESIRED_JSON include a length,
+ * its full actual size is known by pre-calculation, here's the formula why
+ * the length need to minus 3:
+ * 1. The length of "%01d" is 4.
+ * 2. The length of %06lu is 5.
+ * 3. The actual length we will use in case 1. is 1 ( for the state of powerOn ).
+ * 4. The actual length we will use in case 2. is 6 ( for the clientToken length ).
+ * 5. Thus the additional size 3 = 4 + 5 - 1 - 6 + 1 (termination character).
+ *
+ * In your own application, you could calculate the size of the json doc in this way.
+ */
+#define shadowexampleSHADOW_DESIRED_JSON_LENGTH    ( sizeof( shadowexampleSHADOW_DESIRED_JSON ) - 3 )
+
+
+/**
+ * @brief Time in ms to wait between requesting changes to the device shadow.
+ */
+#define shadowexampleMS_BETWEEN_REQUESTS               ( 40000U )
+
+/**
+ * @brief This demo uses task notifications to signal tasks from MQTT callback
+ * functions. shadowexampleMS_TO_WAIT_FOR_NOTIFICATION defines the time, in ticks,
+ * to wait for such a callback.
+ */
+#define shadowexampleMS_TO_WAIT_FOR_NOTIFICATION       ( 5000 )
+
+/**
+ * @brief The maximum amount of time in milliseconds to wait for the commands
+ * to be posted to the MQTT agent should the MQTT agent's command queue be full.
+ * Tasks wait in the Blocked state, so don't use any CPU time.
+ */
+#define shadowexampleMAX_COMMAND_SEND_BLOCK_TIME_MS    ( 200 )
+
+/**
+ * @brief Defines the structure to use as the command callback context in this
+ * demo.
+ */
+struct CommandContext
+{
+    MQTTStatus_t xReturnStatus;
+    TaskHandle_t xTaskToNotify;
+};
+
+extern MQTTAgentContext_t xGlobalMqttAgentContext;
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief When we send an update to the device shadow, and if we care about
+ * the response from cloud (accepted/rejected), remember the clientToken and
+ * use it to match with the response. We set this to 0 when not waiting on a
+ * response.
+ */
+static uint32_t ulClientToken = 0U;
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief Subscribe to the used device shadow topics.
+ *
+ * @return true if the subscribe is successful;
+ * false otherwise.
+ */
+static bool prvSubscribeToShadowPublishTopics( void );
+
+/**
+ * @brief Passed into MQTTAgent_Subscribe() as the callback to execute when the
+ * broker ACKs the SUBSCRIBE message.  Its implementation sends a notification
+ * to the task that called MQTTAgent_Subscribe() to let the task know the
+ * SUBSCRIBE operation completed.  It also sets the xReturnStatus of the
+ * structure passed in as the command's context to the value of the
+ * xReturnStatus parameter - which enables the task to check the status of the
+ * operation.
+ *
+ * See https://freertos.org/mqtt/mqtt-agent-demo.html#example_mqtt_api_call
+ *
+ * @param[in] pxCommandContext Context of the initial command.
+ * @param[in] pxReturnInfo The result of the command.
+ */
+static void prvSubscribeCommandCallback( void * pxCommandContext,
+                                         MQTTAgentReturnInfo_t * pxReturnInfo );
+
+/**
+ * @brief The callback to execute when there is an incoming publish on the
+ * topic for accepted requests. It verifies the document is valid and is being waited on.
+ * If so it notifies the task to inform completion of the update request.
+ *
+ * @param[in] pvIncomingPublishCallbackContext Context of the initial command.
+ * @param[in] pxPublishInfo Deserialized publish.
+ */
+static void prvIncomingPublishUpdateAcceptedCallback( void * pxSubscriptionContext,
+                                                      MQTTPublishInfo_t * pxPublishInfo );
+
+
+
+/**
+ * @brief The callback to execute when there is an incoming publish on the
+ * topic for rejected requests. It verifies the document is valid and is being waited on.
+ * If so it notifies the task to inform completion of the update request.
+ *
+ * @param[in] pvIncomingPublishCallbackContext Context of the initial command.
+ * @param[in] pxPublishInfo Deserialized publish.
+ */
+static void prvIncomingPublishUpdateRejectedCallback( void * pxSubscriptionContext,
+                                                      MQTTPublishInfo_t * pxPublishInfo );
+
+/**
+ * @brief Entry point of shadow demo.
+ *
+ * This main function demonstrates how to use the macros provided by the
+ * Device Shadow library to assemble strings for the MQTT topics defined
+ * by AWS IoT Device Shadow. It uses these macros for topics to subscribe
+ * to:
+ * - SHADOW_TOPIC_STRING_UPDATE_DELTA for "$aws/things/thingName/shadow/update/delta"
+ * - SHADOW_TOPIC_STRING_UPDATE_ACCEPTED for "$aws/things/thingName/shadow/update/accepted"
+ * - SHADOW_TOPIC_STRING_UPDATE_REJECTED for "$aws/things/thingName/shadow/update/rejected"
+ *
+ * It also uses these macros for topics to publish to:
+ * - SHADOW_TOPIC_STIRNG_DELETE for "$aws/things/thingName/shadow/delete"
+ * - SHADOW_TOPIC_STRING_UPDATE for "$aws/things/thingName/shadow/update"
+ */
+void vShadowUpdateTask( void * pvParameters );
+
+/*-----------------------------------------------------------*/
+
+static bool prvSubscribeToShadowUpdateTopics( void )
+{
+    bool xReturnStatus = true;
+    MQTTStatus_t xStatus;
+    uint32_t ulNotificationValue;
+    CommandInfo_t xCommandParams = { 0 };
+
+    /* These must persist until the command is processed. */
+    static MQTTAgentSubscribeArgs_t xSubscribeArgs;
+    static MQTTSubscribeInfo_t xSubscribeInfo[ 2 ];
+
+    /* Context must persist as long as subscription persists. */
+    static CommandContext_t xApplicationDefinedContext = { 0 };
+
+    /* Record the handle of this task in the context that will be used within
+    * the callbacks so the callbacks can send a notification to this task. */
+    xApplicationDefinedContext.xTaskToNotify = xTaskGetCurrentTaskHandle();
+
+    /* Ensure the return status is not accidentally MQTTSuccess already. */
+    xApplicationDefinedContext.xReturnStatus = MQTTBadParameter;
+
+    /* Subscribe to shadow topic for accepted responses for submitted updates. */
+    xSubscribeInfo[ 0 ].pTopicFilter = SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER );
+    xSubscribeInfo[ 0 ].topicFilterLength = SHADOW_TOPIC_LENGTH_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER_LENGTH );
+    xSubscribeInfo[ 0 ].qos = MQTTQoS1;
+    /* Subscribe to shadow topic for rejected responses for submitted updates. */
+    xSubscribeInfo[ 1 ].pTopicFilter = SHADOW_TOPIC_STRING_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER );
+    xSubscribeInfo[ 1 ].topicFilterLength = SHADOW_TOPIC_LENGTH_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER_LENGTH );
+    xSubscribeInfo[ 1 ].qos = MQTTQoS1;
+
+    /* Complete the subscribe information.  The topic string must persist for
+     * duration of subscription - although in this case is it a static const so
+     * will persist for the lifetime of the application. */
+    xSubscribeArgs.pSubscribeInfo = xSubscribeInfo;
+    xSubscribeArgs.numSubscriptions = 2;
+
+    /* Loop in case the queue used to communicate with the MQTT agent is full and
+     * attempts to post to it time out.  The queue will not become full if the
+     * priority of the MQTT agent task is higher than the priority of the task
+     * calling this function. */
+    xTaskNotifyStateClear( NULL );
+    xCommandParams.blockTimeMs = shadowexampleMAX_COMMAND_SEND_BLOCK_TIME_MS;
+    xCommandParams.cmdCompleteCallback = prvSubscribeCommandCallback;
+    xCommandParams.pCmdCompleteCallbackContext = &xApplicationDefinedContext;
+    LogInfo( ( "Sending subscribe request to agent for defender topics." ) );
+
+    do
+    {
+        /* If this fails, the agent's queue is full, so we retry until the agent
+         * has more space in the queue. */
+        xStatus = MQTTAgent_Subscribe( &xGlobalMqttAgentContext,
+                                       &( xSubscribeArgs ),
+                                       &xCommandParams );
+    } while( xStatus != MQTTSuccess );
+
+    /* Wait for acks from subscribe messages - this is optional.  If the
+     * returned value is zero then the wait timed out. */
+    ulNotificationValue = ulTaskNotifyTake( pdFALSE, pdMS_TO_TICKS( shadowexampleMS_TO_WAIT_FOR_NOTIFICATION ) );
+    configASSERT( ulNotificationValue != 0UL );
+
+    /* The callback sets the xReturnStatus member of the context. */
+    if( xApplicationDefinedContext.xReturnStatus != MQTTSuccess )
+    {
+        LogError( ( "Failed to subscribe to shadow update topics." ) );
+        xReturnStatus = false;
+    }
+    else
+    {
+        LogInfo( ( "Received subscribe ack for shadow update topics." ) );
+    }
+
+    /* Add subscriptions so that incoming publishes are routed to the application
+     * callback. */
+
+    if( xReturnStatus == true )
+    {
+        xReturnStatus = addSubscription( ( SubscriptionElement_t * ) xGlobalMqttAgentContext.pIncomingCallbackContext,
+                                         SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER ),
+                                         SHADOW_TOPIC_LENGTH_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER_LENGTH ),
+                                         prvIncomingPublishUpdateAcceptedCallback,
+                                         &xApplicationDefinedContext );
+
+        if( xReturnStatus == false )
+        {
+            LogError( ( "Failed to register an incoming publish callback for topic %.*s.",
+                        SHADOW_TOPIC_LENGTH_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER_LENGTH ),
+                        SHADOW_TOPIC_STRING_UPDATE_ACCEPTED( democonfigCLIENT_IDENTIFIER ) ) );
+            xReturnStatus = false;
+        }
+    }
+
+    if( xReturnStatus == true )
+    {
+        xReturnStatus = addSubscription( ( SubscriptionElement_t * ) xGlobalMqttAgentContext.pIncomingCallbackContext,
+                                         SHADOW_TOPIC_STRING_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER ),
+                                         SHADOW_TOPIC_LENGTH_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER_LENGTH ),
+                                         prvIncomingPublishUpdateRejectedCallback,
+                                         &xApplicationDefinedContext );
+
+        if( xReturnStatus == false )
+        {
+            LogError( ( "Failed to register an incoming publish callback for topic %.*s.",
+                        SHADOW_TOPIC_LENGTH_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER_LENGTH ),
+                        SHADOW_TOPIC_STRING_UPDATE_REJECTED( democonfigCLIENT_IDENTIFIER ) ) );
+            xReturnStatus = false;
+        }
+    }
+
+    return xReturnStatus;
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvSubscribeCommandCallback( void * pxCommandContext,
+                                         MQTTAgentReturnInfo_t * pxReturnInfo )
+{
+    CommandContext_t * pxApplicationDefinedContext = ( CommandContext_t * ) pxCommandContext;
+
+    /* Store the result in the application defined context so the calling task
+     * can check it. */
+    pxApplicationDefinedContext->xReturnStatus = pxReturnInfo->returnCode;
+
+    xTaskNotifyGive( pxApplicationDefinedContext->xTaskToNotify );
+}
+
+
+/*-----------------------------------------------------------*/
+
+static void prvIncomingPublishUpdateAcceptedCallback( void * pxSubscriptionContext,
+                                                      MQTTPublishInfo_t * pxPublishInfo )
+{
+    char * pcOutValue = NULL;
+    uint32_t ulOutValueLength = 0U;
+    uint32_t ulReceivedToken = 0U;
+    JSONStatus_t result = JSONSuccess;
+
+    CommandContext_t * pxApplicationDefinedContext = ( CommandContext_t * ) pxSubscriptionContext;
+
+    configASSERT( pxPublishInfo != NULL );
+    configASSERT( pxPublishInfo->pPayload != NULL );
+
+    LogDebug( ( "/update/accepted JSON payload: %s.", ( const char * ) pxPublishInfo->pPayload ) );
+
+    /* Handle the reported state with state change in /update/accepted topic.
+     * Thus we will retrieve the client token from the JSON document to see if
+     * it's the same one we sent with reported state on the /update topic.
+     * The payload will look similar to this:
+     *  {
+     *      "state": {
+     *          "desired": {
+     *             "powerOn": 1
+     *          }
+     *      },
+     *      "metadata": {
+     *          "desired": {
+     *              "powerOn": {
+     *                  "timestamp": 1596573647
+     *              }
+     *          }
+     *      },
+     *      "version": 14698,
+     *      "timestamp": 1596573647,
+     *      "clientToken": "022485"
+     *  }
+     */
+
+    /* Make sure the payload is a valid json document. */
+    result = JSON_Validate( pxPublishInfo->pPayload,
+                            pxPublishInfo->payloadLength );
+
+    if( result != JSONSuccess )
+    {
+        LogError( ( "Invalid JSON document recieved!" ) );
+    }
+    else
+    {
+        /* Get clientToken from json documents. */
+        result = JSON_Search( ( char * ) pxPublishInfo->pPayload,
+                              pxPublishInfo->payloadLength,
+                              "clientToken",
+                              sizeof( "clientToken" ) - 1,
+                              &pcOutValue,
+                              ( size_t * ) &ulOutValueLength );
+    }
+
+    if( result != JSONSuccess )
+    {
+        LogDebug( ( "Ignoring publish on /update/accepted with no clientToken field." ) );
+    }
+    else
+    {
+        /* Convert the code to an unsigned integer value. */
+        ulReceivedToken = ( uint32_t ) strtoul( pcOutValue, NULL, 10 );
+
+        /* If we are waiting for a response, ulClientToken will be the token for the response
+         * we are waiting for, else it will be 0. ulRecievedToken may not match if the response is
+         * not for us or if it is is a response that arrived after we timed out
+         * waiting for it.
+         */
+        if( ulReceivedToken != ulClientToken )
+        {
+            LogDebug( ( "Ignoring publish on /update/accepted with clientToken %lu.", ( unsigned long ) ulReceivedToken ) );
+        }
+        else
+        {
+            LogInfo( ( "Received accepted response for update with token %lu. ", ( unsigned long ) ulClientToken ) );
+
+            /* Wake up the shadow task which is waiting for this response. */
+            xTaskNotifyGive( pxApplicationDefinedContext->xTaskToNotify );
+        }
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+static void prvIncomingPublishUpdateRejectedCallback( void * pxSubscriptionContext,
+                                                      MQTTPublishInfo_t * pxPublishInfo )
+{
+    JSONStatus_t result = JSONSuccess;
+    char * pcOutValue = NULL;
+    uint32_t ulOutValueLength = 0UL;
+    CommandContext_t * pxApplicationDefinedContext = ( CommandContext_t * ) pxSubscriptionContext;
+    uint32_t ulReceivedToken = 0U;
+
+    configASSERT( pxPublishInfo != NULL );
+    configASSERT( pxPublishInfo->pPayload != NULL );
+
+    LogDebug( ( "/update/rejected json payload: %s.", ( const char * ) pxPublishInfo->pPayload ) );
+
+    /* The payload will look similar to this:
+     * {
+     *    "code": error-code,
+     *    "message": "error-message",
+     *    "timestamp": timestamp,
+     *    "clientToken": "token"
+     * }
+     */
+
+    /* Make sure the payload is a valid json document. */
+    result = JSON_Validate( pxPublishInfo->pPayload,
+                            pxPublishInfo->payloadLength );
+
+    if( result != JSONSuccess )
+    {
+        LogError( ( "Invalid JSON document recieved!" ) );
+    }
+    else
+    {
+        /* Get clientToken from json documents. */
+        result = JSON_Search( ( char * ) pxPublishInfo->pPayload,
+                              pxPublishInfo->payloadLength,
+                              "clientToken",
+                              sizeof( "clientToken" ) - 1,
+                              &pcOutValue,
+                              ( size_t * ) &ulOutValueLength );
+    }
+
+    if( result != JSONSuccess )
+    {
+        LogDebug( ( "Ignoring publish on /update/rejected with clientToken %lu.", ( unsigned long ) ulReceivedToken ) );
+    }
+    else
+    {
+        /* Convert the code to an unsigned integer value. */
+        ulReceivedToken = ( uint32_t ) strtoul( pcOutValue, NULL, 10 );
+
+        /* If we are waiting for a response, ulClientToken will be the token for the response
+         * we are waiting for, else it will be 0. ulRecievedToken may not match if the response is
+         * not for us or if it is is a response that arrived after we timed out
+         * waiting for it.
+         */
+        if( ulReceivedToken != ulClientToken )
+        {
+            LogDebug( ( "Ignoring publish on /update/rejected with clientToken %lu.", ( unsigned long ) ulReceivedToken ) );
+        }
+        else
+        {
+            /*  Obtain the error code. */
+            result = JSON_Search( ( char * ) pxPublishInfo->pPayload,
+                                  pxPublishInfo->payloadLength,
+                                  "code",
+                                  sizeof( "code" ) - 1,
+                                  &pcOutValue,
+                                  ( size_t * ) &ulOutValueLength );
+
+            if( result != JSONSuccess )
+            {
+                LogWarn( ( "Received rejected response for update with token %lu and no error code.", ( unsigned long ) ulClientToken ) );
+            }
+            else
+            {
+                LogWarn( ( "Received rejected response for update with token %lu and error code %.*s.", ( unsigned long ) ulClientToken,
+                           ulOutValueLength,
+                           pcOutValue ) );
+            }
+
+            /* Wake up the shadow task which is waiting for this response. */
+            xTaskNotifyGive( pxApplicationDefinedContext->xTaskToNotify );
+        }
+    }
+}
+
+/*-----------------------------------------------------------*/
+
+void vShadowUpdateTask( void * pvParameters )
+{
+    bool xStatus = true;
+    uint32_t ulNotificationValue;
+    static MQTTPublishInfo_t xPublishInfo = { 0 };
+    CommandInfo_t xCommandParams = { 0 };
+    MQTTStatus_t xCommandAdded;
+    uint32_t desiredState = 0;
+
+    /* A buffer containing the desired document. It has static duration to prevent
+     * it from being placed on the call stack. */
+    static char pcDesiredDocument[ shadowexampleSHADOW_DESIRED_JSON_LENGTH + 1 ] = { 0 };
+
+    /* Remove compiler warnings about unused parameters. */
+    ( void ) pvParameters;
+
+    /* Set up the CommandInfo_t for the demo loop.
+     * We do not need a completion callback here since for publishes, we expect to get a
+     * response on the appropriate topics for accepted or rejected reports. */
+    xCommandParams.blockTimeMs = shadowexampleMAX_COMMAND_SEND_BLOCK_TIME_MS;
+    xCommandParams.cmdCompleteCallback = NULL;
+
+    /* Set up MQTTPublishInfo_t for the desired updates. */
+    xPublishInfo.qos = MQTTQoS1;
+    xPublishInfo.pTopicName = SHADOW_TOPIC_STRING_UPDATE( democonfigCLIENT_IDENTIFIER );
+    xPublishInfo.topicNameLength = SHADOW_TOPIC_LENGTH_UPDATE( democonfigCLIENT_IDENTIFIER_LENGTH );
+    xPublishInfo.pPayload = pcDesiredDocument;
+    xPublishInfo.payloadLength = ( shadowexampleSHADOW_DESIRED_JSON_LENGTH + 1 );
+
+    /* Subscribe to Shadow topics. */
+    xStatus = prvSubscribeToShadowUpdateTopics();
+
+    if( xStatus == true )
+    {
+        for( ; ; )
+        {
+            vTaskDelay( pdMS_TO_TICKS( shadowexampleMS_BETWEEN_REQUESTS ) );
+
+
+            /* Create a new client token and save it for use in the update accepted and rejected callbacks. */
+            ulClientToken = ( xTaskGetTickCount() % 1000000 );
+
+            /* Generate update report. */
+            ( void ) memset( pcDesiredDocument,
+                             0x00,
+                             sizeof( pcDesiredDocument ) );
+
+            snprintf( pcDesiredDocument,
+                      shadowexampleSHADOW_DESIRED_JSON_LENGTH + 1,
+                      shadowexampleSHADOW_DESIRED_JSON,
+                      ( unsigned int ) desiredState,
+                      ( long unsigned ) ulClientToken );
+
+            /* Send desired state. */
+            LogInfo( ( "Publishing to /update with following client token %lu.", ( long unsigned ) ulClientToken ) );
+            LogDebug( ( "Publish content: %.*s", shadowexampleSHADOW_DESIRED_JSON_LENGTH, pcDesiredDocument ) );
+
+            xCommandAdded = MQTTAgent_Publish( &xGlobalMqttAgentContext,
+                                               &xPublishInfo,
+                                               &xCommandParams );
+
+            /* Wait for the response to our report. */
+            ulNotificationValue = ulTaskNotifyTake( pdFALSE, pdMS_TO_TICKS( shadowexampleMS_TO_WAIT_FOR_NOTIFICATION ) );
+
+            if( ulNotificationValue == 0 )
+            {
+                LogError( ( "Timed out waiting for response to report." ) );
+            }
+
+            /* Clear the client token */
+            ulClientToken = 0;
+
+            desiredState = !desiredState;
+            LogDebug( ( "Sleeping until time for next publish." ) );
+        }
+    }
+}
+
+/*-----------------------------------------------------------*/

--- a/source/shadow_demo.c
+++ b/source/shadow_demo.c
@@ -1,0 +1,101 @@
+/*
+ * FreeRTOS V202012.00
+ * Copyright (C) 2020 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/*
+ * Demo for showing how to use the Device Shadow library with the MQTT Agent. The Device
+ * Shadow library provides macros and helper functions for assembling MQTT topics
+ * strings, and for determining whether an incoming MQTT message is related to the
+ * device shadow.
+ *
+ * This demo contains two tasks. The first demonstrates typical use of the Device Shadow library
+ * by keeping the shadow up to date and reacting to changes made to the shadow.
+ * If enabled, the second task uses the Device Shadow library to request change to the device
+ * shadow. This serves to create events for the first task to react to for demonstration purposes.
+ */
+
+/* Kernel includes. */
+#include "FreeRTOS.h"
+#include "task.h"
+
+/* Demo config. */
+#include "demo_config.h"
+
+/**
+ * democonfigCLIENT_IDENTIFIER is required. Throw compilation error if it is not defined.
+ */
+#ifndef democonfigCLIENT_IDENTIFIER
+    #error "Please define democonfigCLIENT_IDENTIFIER in demo_config.h to the thing name registered with AWS IoT Core."
+#endif
+
+/**
+ * Enable/disable the
+ */
+#define shadowexampleENABLE_UPDATE_TASK    1
+
+/*-----------------------------------------------------------*/
+
+/**
+ * @brief The task used to demonstrate using the Shadow API on a device.
+ *
+ * @param[in] pvParameters Parameters as passed at the time of task creation. Not
+ * used in this example.
+ */
+extern void vShadowDeviceTask( void * pvParameters );
+
+/**
+ * @brief The task used to request changes to the device's shadow.
+ *
+ * @param[in] pvParameters Parameters as passed at the time of task creation. Not
+ * used in this example.
+ */
+extern void vShadowUpdateTask( void * pvParameters );
+
+/*-----------------------------------------------------------*/
+
+/*
+ * @brief Create the tasks that demonstrate the Device Shadow library API.
+ */
+void vStartShadowDemo( configSTACK_DEPTH_TYPE uxStackSize,
+                       UBaseType_t uxPriority )
+{
+    xTaskCreate( vShadowDeviceTask, /* Function that implements the task. */
+                 "ShadowDevice",    /* Text name for the task - only used for debugging. */
+                 uxStackSize,       /* Size of stack (in words, not bytes) to allocate for the task. */
+                 NULL,              /* Task parameter - not used in this case. */
+                 uxPriority,        /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */
+                 NULL );            /* Used to pass out a handle to the created task - not used in this case. */
+
+    #if ( shadowexampleENABLE_UPDATE_TASK == 1 )
+        xTaskCreate( vShadowUpdateTask, /* Function that implements the task. */
+                     "ShadowUpdate",    /* Text name for the task - only used for debugging. */
+                     uxStackSize,       /* Size of stack (in words, not bytes) to allocate for the task. */
+                     NULL,              /* Task parameter - not used in this case. */
+                     uxPriority,        /* Task priority, must be between 0 and configMAX_PRIORITIES - 1. */
+                     NULL );            /* Used to pass out a handle to the created task - not used in this case. */
+    #endif
+}
+
+/*-----------------------------------------------------------*/

--- a/source/shadow_demo.c
+++ b/source/shadow_demo.c
@@ -51,7 +51,8 @@
 #endif
 
 /**
- * Enable/disable the
+ * Enable/disable the task that sends desired state requests to the Device Shadow service for
+ * demonstration purposes.
  */
 #define shadowexampleENABLE_UPDATE_TASK    1
 


### PR DESCRIPTION
Adds two tasks for the shadow API. One manages syncing the device and its shadow, and one makes requests to change the state of the shadow.